### PR TITLE
Feat: 프로필 뷰 생성 및 프론트엔드 완성

### DIFF
--- a/YeDi/YeDi.xcodeproj/project.pbxproj
+++ b/YeDi/YeDi.xcodeproj/project.pbxproj
@@ -12,6 +12,12 @@
 		2FFE87292AC12C4D00A7A728 /* CMSearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FFE87282AC12C4D00A7A728 /* CMSearchView.swift */; };
 		2FFE872B2AC1462B00A7A728 /* CMSearchHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FFE872A2AC1462B00A7A728 /* CMSearchHistoryView.swift */; };
 		2FFE872D2AC1464100A7A728 /* CMSearchResultView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FFE872C2AC1464100A7A728 /* CMSearchResultView.swift */; };
+		2FFE872F2AC171A300A7A728 /* CMSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FFE872E2AC171A300A7A728 /* CMSettingsView.swift */; };
+		2FFE87312AC171FF00A7A728 /* CMNotificationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FFE87302AC171FF00A7A728 /* CMNotificationView.swift */; };
+		2FFE87332AC174C700A7A728 /* CMSegmentedControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FFE87322AC174C700A7A728 /* CMSegmentedControl.swift */; };
+		2FFE87352AC17D0D00A7A728 /* CMFollowingListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FFE87342AC17D0D00A7A728 /* CMFollowingListView.swift */; };
+		2FFE87372AC17D2A00A7A728 /* CMReviewListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FFE87362AC17D2A00A7A728 /* CMReviewListView.swift */; };
+		2FFE87392AC17E2C00A7A728 /* CMLikeListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FFE87382AC17E2C00A7A728 /* CMLikeListView.swift */; };
 		639DB6332AC10E44002692E5 /* FirebaseAppCheck in Frameworks */ = {isa = PBXBuildFile; productRef = 639DB6322AC10E44002692E5 /* FirebaseAppCheck */; };
 		639DB6352AC10E44002692E5 /* FirebaseAppDistribution-Beta in Frameworks */ = {isa = PBXBuildFile; productRef = 639DB6342AC10E44002692E5 /* FirebaseAppDistribution-Beta */; };
 		639DB6372AC10E44002692E5 /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 639DB6362AC10E44002692E5 /* FirebaseAuth */; };
@@ -59,6 +65,12 @@
 		2FFE87282AC12C4D00A7A728 /* CMSearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMSearchView.swift; sourceTree = "<group>"; };
 		2FFE872A2AC1462B00A7A728 /* CMSearchHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMSearchHistoryView.swift; sourceTree = "<group>"; };
 		2FFE872C2AC1464100A7A728 /* CMSearchResultView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMSearchResultView.swift; sourceTree = "<group>"; };
+		2FFE872E2AC171A300A7A728 /* CMSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMSettingsView.swift; sourceTree = "<group>"; };
+		2FFE87302AC171FF00A7A728 /* CMNotificationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMNotificationView.swift; sourceTree = "<group>"; };
+		2FFE87322AC174C700A7A728 /* CMSegmentedControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMSegmentedControl.swift; sourceTree = "<group>"; };
+		2FFE87342AC17D0D00A7A728 /* CMFollowingListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMFollowingListView.swift; sourceTree = "<group>"; };
+		2FFE87362AC17D2A00A7A728 /* CMReviewListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMReviewListView.swift; sourceTree = "<group>"; };
+		2FFE87382AC17E2C00A7A728 /* CMLikeListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMLikeListView.swift; sourceTree = "<group>"; };
 		639DB6602AC10F13002692E5 /* DesignerMainTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignerMainTabView.swift; sourceTree = "<group>"; };
 		639DB6682AC10F7E002692E5 /* ClientMainTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientMainTabView.swift; sourceTree = "<group>"; };
 		639DB66F2AC119FE002692E5 /* CMHomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMHomeView.swift; sourceTree = "<group>"; };
@@ -226,6 +238,12 @@
 			isa = PBXGroup;
 			children = (
 				639DB6772AC11A5D002692E5 /* CMProfileView.swift */,
+				2FFE87322AC174C700A7A728 /* CMSegmentedControl.swift */,
+				2FFE87382AC17E2C00A7A728 /* CMLikeListView.swift */,
+				2FFE87342AC17D0D00A7A728 /* CMFollowingListView.swift */,
+				2FFE87362AC17D2A00A7A728 /* CMReviewListView.swift */,
+				2FFE87302AC171FF00A7A728 /* CMNotificationView.swift */,
+				2FFE872E2AC171A300A7A728 /* CMSettingsView.swift */,
 			);
 			path = CMProfile;
 			sourceTree = "<group>";
@@ -409,21 +427,27 @@
 			files = (
 				639DB6722AC11A3A002692E5 /* CMFilterView.swift in Sources */,
 				639DB6692AC10F7E002692E5 /* ClientMainTabView.swift in Sources */,
+				2FFE87352AC17D0D00A7A728 /* CMFollowingListView.swift in Sources */,
 				639DB6812AC11B21002692E5 /* DMMainChattingView.swift in Sources */,
 				639DB6872AC11B56002692E5 /* DMPostView.swift in Sources */,
 				639DB6742AC11A46002692E5 /* CMReservationView.swift in Sources */,
+				2FFE87312AC171FF00A7A728 /* CMNotificationView.swift in Sources */,
 				639DB6842AC11B3B002692E5 /* DMReservationView.swift in Sources */,
+				2FFE87332AC174C700A7A728 /* CMSegmentedControl.swift in Sources */,
 				639DB6782AC11A5D002692E5 /* CMProfileView.swift in Sources */,
 				2FFE872B2AC1462B00A7A728 /* CMSearchHistoryView.swift in Sources */,
 				639DB6702AC119FE002692E5 /* CMHomeView.swift in Sources */,
+				2FFE872F2AC171A300A7A728 /* CMSettingsView.swift in Sources */,
 				639DB67A2AC11AC2002692E5 /* DMReviewView.swift in Sources */,
 				639DB6762AC11A52002692E5 /* CMMainChattingView.swift in Sources */,
 				2FFE87292AC12C4D00A7A728 /* CMSearchView.swift in Sources */,
 				63CD89B32ABD85C300E70A56 /* ContentView.swift in Sources */,
 				63CD89B12ABD85C300E70A56 /* YeDiApp.swift in Sources */,
 				094759802AC1656C0066484F /* CMHomeCell.swift in Sources */,
+				2FFE87392AC17E2C00A7A728 /* CMLikeListView.swift in Sources */,
 				639DB6612AC10F13002692E5 /* DesignerMainTabView.swift in Sources */,
 				639DB67E2AC11AF5002692E5 /* DMProfileView.swift in Sources */,
+				2FFE87372AC17D2A00A7A728 /* CMReviewListView.swift in Sources */,
 				2FFE872D2AC1464100A7A728 /* CMSearchResultView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/YeDi/YeDi/Client/View/CMProfile/CMFollowingListView.swift
+++ b/YeDi/YeDi/Client/View/CMProfile/CMFollowingListView.swift
@@ -1,0 +1,21 @@
+//
+//  CMFollowingListView.swift
+//  YeDi
+//
+//  Created by 박채영 on 2023/09/25.
+//
+
+import SwiftUI
+
+struct CMFollowingListView: View {
+    var body: some View {
+        VStack {
+            Text("팔로잉한 디자이너가 없습니다.")
+                .padding()
+        }
+    }
+}
+
+#Preview {
+    CMFollowingListView()
+}

--- a/YeDi/YeDi/Client/View/CMProfile/CMLikeListView.swift
+++ b/YeDi/YeDi/Client/View/CMProfile/CMLikeListView.swift
@@ -1,0 +1,21 @@
+//
+//  CMLikeListView.swift
+//  YeDi
+//
+//  Created by 박채영 on 2023/09/25.
+//
+
+import SwiftUI
+
+struct CMLikeListView: View {
+    var body: some View {
+        VStack {
+            Text("찜한 게시물이 없습니다.")
+                .padding()
+        }
+    }
+}
+
+#Preview {
+    CMLikeListView()
+}

--- a/YeDi/YeDi/Client/View/CMProfile/CMNotificationView.swift
+++ b/YeDi/YeDi/Client/View/CMProfile/CMNotificationView.swift
@@ -1,0 +1,18 @@
+//
+//  CMNotificationView.swift
+//  YeDi
+//
+//  Created by 박채영 on 2023/09/25.
+//
+
+import SwiftUI
+
+struct CMNotificationView: View {
+    var body: some View {
+        Text("NotificationView")
+    }
+}
+
+#Preview {
+    CMNotificationView()
+}

--- a/YeDi/YeDi/Client/View/CMProfile/CMProfileView.swift
+++ b/YeDi/YeDi/Client/View/CMProfile/CMProfileView.swift
@@ -9,10 +9,54 @@ import SwiftUI
 
 struct CMProfileView: View {
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        NavigationStack {
+            VStack {
+                HStack {
+                    VStack(alignment: .leading) {
+                        Text("@@@님")
+                        Text("오늘도 빛나는 하루 보내세요")
+                    }
+                    .font(.system(size: 20, weight: .bold))
+                    Spacer()
+                    Image(systemName: "person.circle.fill")
+                        .font(.system(size: 50))
+                }
+                .padding()
+                
+                Text("정보 수정")
+                    .font(.system(size: 15))
+                    .frame(width: 350, height: 35)
+                    .border(.gray)
+                    .padding(.bottom, 40)
+                
+                CMSegmentedControl()
+                
+                Spacer()
+            }
+        }
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                NavigationLink {
+                    CMNotificationView()
+                } label: {
+                    Image(systemName: "bell")
+                        .foregroundStyle(.black)
+                }
+            }
+            ToolbarItem(placement: .topBarTrailing) {
+                NavigationLink {
+                    CMSettingsView()
+                } label: {
+                    Image(systemName: "gearshape")
+                        .foregroundStyle(.black)
+                }
+            }
+        }
     }
 }
 
 #Preview {
-    CMProfileView()
+    NavigationStack {
+        CMProfileView()
+    }
 }

--- a/YeDi/YeDi/Client/View/CMProfile/CMReviewListView.swift
+++ b/YeDi/YeDi/Client/View/CMProfile/CMReviewListView.swift
@@ -1,0 +1,21 @@
+//
+//  CMReviewListView.swift
+//  YeDi
+//
+//  Created by 박채영 on 2023/09/25.
+//
+
+import SwiftUI
+
+struct CMReviewListView: View {
+    var body: some View {
+        VStack {
+            Text("작성된 리뷰가 없습니다.")
+                .padding()
+        }
+    }
+}
+
+#Preview {
+    CMReviewListView()
+}

--- a/YeDi/YeDi/Client/View/CMProfile/CMSegmentedControl.swift
+++ b/YeDi/YeDi/Client/View/CMProfile/CMSegmentedControl.swift
@@ -1,0 +1,50 @@
+//
+//  CMSegmentedControl.swift
+//  YeDi
+//
+//  Created by 박채영 on 2023/09/25.
+//
+
+import SwiftUI
+
+struct CMSegmentedControl: View {
+    @State var selectedSegment: String = "찜한 게시물"
+    
+    let segments: [String] = ["찜한 게시물", "팔로잉", "리뷰"]
+    
+    var body: some View {
+        VStack {
+            HStack(spacing: 0) {
+                ForEach(segments, id: \.self) { segment in
+                    Button(action: {
+                        selectedSegment = segment
+                    }, label: {
+                        VStack {
+                            Text(segment)
+                                .fontWeight(selectedSegment == segment ? .semibold : .medium)
+                                .foregroundStyle(.black)
+                            Rectangle()
+                                .fill(selectedSegment == segment ? .black : .white)
+                                .frame(width: 120, height: 3)
+                        }
+                    })
+                }
+            }
+            
+            switch selectedSegment {
+            case "찜한 게시물":
+                CMLikeListView()
+            case "팔로잉":
+                CMFollowingListView()
+            case "리뷰":
+                CMReviewListView()
+            default:
+                Text("")
+            }
+        }
+    }
+}
+
+#Preview {
+    CMSegmentedControl()
+}

--- a/YeDi/YeDi/Client/View/CMProfile/CMSettingsView.swift
+++ b/YeDi/YeDi/Client/View/CMProfile/CMSettingsView.swift
@@ -1,0 +1,18 @@
+//
+//  CMSettingsView.swift
+//  YeDi
+//
+//  Created by 박채영 on 2023/09/25.
+//
+
+import SwiftUI
+
+struct CMSettingsView: View {
+    var body: some View {
+        Text("SettingsView")
+    }
+}
+
+#Preview {
+    CMSettingsView()
+}


### PR DESCRIPTION
- CMProfileVIew: 프로필 메인 뷰
  - CMNotificationView: 프로필 우측 상단에서 연결되는 알림 뷰
  - CMSettingsView: 프로필 우측 상단에서 연결되는 세팅 뷰
  - CMSegmentedControl: 찜한 게시물, 팔로잉, 리뷰 중 선택할 수 있는 커스텀 SegmentedControl
    - CMLikeListVIew: 찜한 게시물을 볼 수 있는 뷰
    - CMFollowingListView: 팔로잉한 디자이너를 볼 수 있는 뷰
    - CMReviewListView: 내가 작성한 리뷰를 볼 수 있는 뷰