### PR TITLE
Feat: 프로필 뷰 및 프로필 편집 뷰 파이어스토어 연동 완료

### DIFF
--- a/YeDi/YeDi.xcodeproj/project.pbxproj
+++ b/YeDi/YeDi.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		1D9067212AC1F61D0028A660 /* DMGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D9067202AC1F61D0028A660 /* DMGridView.swift */; };
 		1DA52F562AC2CB69002E0D75 /* DMNewPostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA52F552AC2CB69002E0D75 /* DMNewPostView.swift */; };
 		1DB59C672ACD9C9C008EAD5E /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 1DB59C662ACD9C9C008EAD5E /* GoogleService-Info.plist */; };
+		2F0A21912ACE753F0070CA42 /* CMProfileViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0A21902ACE753F0070CA42 /* CMProfileViewModel.swift */; };
 		3BAB00EB2ACD92D6009053A4 /* DMAccount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BAB00EA2ACD92D5009053A4 /* DMAccount.swift */; };
 		3BAB00F12ACD948C009053A4 /* DMExpandableText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BAB00F02ACD948B009053A4 /* DMExpandableText.swift */; };
 		3BAB00F32ACD97EB009053A4 /* ReservationSDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BAB00F22ACD97EA009053A4 /* ReservationSDetail.swift */; };
@@ -108,6 +109,7 @@
 		1D9067202AC1F61D0028A660 /* DMGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DMGridView.swift; sourceTree = "<group>"; };
 		1DA52F552AC2CB69002E0D75 /* DMNewPostView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DMNewPostView.swift; sourceTree = "<group>"; };
 		1DB59C662ACD9C9C008EAD5E /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
+		2F0A21902ACE753F0070CA42 /* CMProfileViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMProfileViewModel.swift; sourceTree = "<group>"; };
 		3BAB00EA2ACD92D5009053A4 /* DMAccount.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DMAccount.swift; sourceTree = "<group>"; };
 		3BAB00F02ACD948B009053A4 /* DMExpandableText.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DMExpandableText.swift; sourceTree = "<group>"; };
 		3BAB00F22ACD97EA009053A4 /* ReservationSDetail.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReservationSDetail.swift; sourceTree = "<group>"; };
@@ -313,6 +315,7 @@
 			children = (
 				3BCF2C382ACD4247009C18C2 /* PostDetailViewModel.swift */,
 				3BCF2C392ACD4247009C18C2 /* CMPostViewModel.swift */,
+				2F0A21902ACE753F0070CA42 /* CMProfileViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -683,6 +686,7 @@
 				1D9067212AC1F61D0028A660 /* DMGridView.swift in Sources */,
 				3BCF2C8C2ACD4248009C18C2 /* CMFollowingListView.swift in Sources */,
 				3BCF2C862ACD4248009C18C2 /* CMLikePostListView.swift in Sources */,
+				2F0A21912ACE753F0070CA42 /* CMProfileViewModel.swift in Sources */,
 				3BCF2C8D2ACD4248009C18C2 /* CMReviewListView.swift in Sources */,
 				9666A21B2ACDBB6D0081C711 /* TimeSettingDetail.swift in Sources */,
 				3BCF2C782ACD4248009C18C2 /* CMReservationCancelView.swift in Sources */,

--- a/YeDi/YeDi/Client/View/CMProfile/CMProfileEdit/CMClientInfoEditView.swift
+++ b/YeDi/YeDi/Client/View/CMProfile/CMProfileEdit/CMClientInfoEditView.swift
@@ -36,6 +36,7 @@ struct CMClientInfoEditView: View {
                     ForEach(genders, id: \.self) { gender in
                         Button(action: {
                             selectedGender = gender
+                            clientGender = selectedGender
                         }, label: {
                             Text(gender)
                                 .padding(EdgeInsets(top: 10, leading: 20, bottom: 10, trailing: 20))
@@ -94,6 +95,13 @@ struct CMClientInfoEditView: View {
             }
             .presentationDetents([.fraction(0.4)])
         })
+        .onAppear {
+            let dateFormatter = DateFormatter()
+            dateFormatter.dateFormat = "yyyy.MM.dd."
+            
+            selectedGender = clientGender
+            selectedBirthDate = dateFormatter.date(from: clientBirthDate) ?? Date()
+        }
     }
 }
 

--- a/YeDi/YeDi/Client/View/CMProfile/CMProfileEdit/CMProfileEditView.swift
+++ b/YeDi/YeDi/Client/View/CMProfile/CMProfileEdit/CMProfileEditView.swift
@@ -11,6 +11,9 @@ import PhotosUI
 struct CMProfileEditView: View {
     @Environment(\.dismiss) var dismiss
     
+    @EnvironmentObject var userAuth: UserAuth
+    @EnvironmentObject var profileVM: CMProfileViewModel
+    
     @State private var selectedPhoto: PhotosPickerItem? = nil
     @State private var selectedPhotoData: Data = Data()
     
@@ -107,7 +110,25 @@ struct CMProfileEditView: View {
             
             Spacer()
             Button(action: {
-                // TODO: 이메일, 휴대폰 형식 확인 > 변경 내용 저장
+                if let clientId = userAuth.currentClientID {
+                    let newClient = Client(
+                        id: clientId,
+                        name: clientName,
+                        email: accountEmail,
+                        profileImageURLString: "",
+                        phoneNumber: accountPhoneNumber,
+                        gender: clientGender,
+                        birthDate: clientBirthDate,
+                        favoriteStyle: "",
+                        chatRooms: []
+                    )
+                    Task {
+                        await profileVM.updateClientProfile(
+                            userAuth: userAuth,
+                            newClient: newClient
+                        )
+                    }
+                }
                 dismiss()
             }, label: {
                 Text("저장")
@@ -119,9 +140,19 @@ struct CMProfileEditView: View {
         .navigationTitle("")
         .navigationBarTitleDisplayMode(.inline)
         .toolbar(.hidden, for: .tabBar)
+        .onAppear {
+            clientName = profileVM.client.name
+            clientGender = profileVM.client.gender
+            clientBirthDate = profileVM.client.birthDate
+            
+            accountEmail = profileVM.client.email
+            accountPhoneNumber = profileVM.client.phoneNumber
+        }
     }
 }
 
 #Preview {
     CMProfileEditView()
+        .environmentObject(UserAuth())
+        .environmentObject(CMProfileViewModel())
 }

--- a/YeDi/YeDi/Client/View/CMProfile/CMProfileView.swift
+++ b/YeDi/YeDi/Client/View/CMProfile/CMProfileView.swift
@@ -8,12 +8,15 @@
 import SwiftUI
 
 struct CMProfileView: View {
+    @EnvironmentObject var userAuth: UserAuth
+    @StateObject var profileVM: CMProfileViewModel = CMProfileViewModel()
+    
     var body: some View {
         NavigationStack {
             VStack {
                 HStack {
                     VStack(alignment: .leading) {
-                        Text("김고객님")
+                        Text("\(profileVM.client.name)님")
                         Text("오늘도 빛나는 하루 보내세요")
                     }
                     .font(.system(size: 20, weight: .bold))
@@ -23,7 +26,10 @@ struct CMProfileView: View {
                 }
                 .padding()
                 
-                NavigationLink(destination: CMProfileEditView()) {
+                NavigationLink {
+                    CMProfileEditView()
+                        .environmentObject(profileVM)
+                } label: {
                     Text("정보 수정")
                         .frame(width: 350, height: 40)
                         .background(.black)
@@ -37,6 +43,7 @@ struct CMProfileView: View {
                 Spacer()
             }
         }
+        .padding([.leading, .trailing], 5)
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
                 NavigationLink {
@@ -55,11 +62,17 @@ struct CMProfileView: View {
                 }
             }
         }
+        .onAppear {
+            Task {
+                await profileVM.fetchClientProfile(userAuth: userAuth)
+            }
+        }
     }
 }
 
 #Preview {
     NavigationStack {
         CMProfileView()
+            .environmentObject(UserAuth())
     }
 }

--- a/YeDi/YeDi/Client/View/ClientMainTabView.swift
+++ b/YeDi/YeDi/Client/View/ClientMainTabView.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct ClientMainTabView: View {
+    @EnvironmentObject var userAuth: UserAuth
+    
     @State private var selectedIndex = 0
     
     var body: some View {
@@ -59,4 +61,5 @@ struct ClientMainTabView: View {
 
 #Preview {
     ClientMainTabView()
+        .environmentObject(UserAuth())
 }

--- a/YeDi/YeDi/Client/ViewModel/CMProfileViewModel.swift
+++ b/YeDi/YeDi/Client/ViewModel/CMProfileViewModel.swift
@@ -1,0 +1,51 @@
+//
+//  CMProfileViewModel.swift
+//  YeDi
+//
+//  Created by 박채영 on 2023/10/05.
+//
+
+import SwiftUI
+import FirebaseFirestore
+
+final class CMProfileViewModel: ObservableObject {
+    @Published var client: Client = Client(
+        id: "",
+        name: "",
+        email: "",
+        profileImageURLString: "",
+        phoneNumber: "",
+        gender: "",
+        birthDate: "",
+        favoriteStyle: "",
+        chatRooms: []
+    )
+    
+    let collectionRef = Firestore.firestore().collection("clients")
+    
+    @MainActor
+    func fetchClientProfile(userAuth: UserAuth) async {
+        do {
+            if let clientId = userAuth.currentClientID {
+                let docSnapshot = try await collectionRef.document(clientId).getDocument()
+                
+                self.client = try docSnapshot.data(as: Client.self)
+            }
+        } catch {
+            print("Error fetching client profile: \(error)")
+        }
+    }
+    
+    @MainActor
+    func updateClientProfile(userAuth: UserAuth, newClient: Client) async {
+        do {
+            if let clientId = userAuth.currentClientID {
+                try collectionRef.document(clientId).setData(from: newClient)
+                
+                self.client = newClient
+            }
+        } catch {
+            print("Error updating client profile: \(error)")
+        }
+    }
+}


### PR DESCRIPTION
- Client/ViewModel/CMProfileViewModel
  - 로그인한 사용자의 id 값 > 파이어스토어로부터 Client 구조체에 맞게 데이터 패치 진행
  - 수정 및 반영 비동기 처리 (단, 프로필 사진 수정은 아직 불가함)

![simulator_screenshot_07E83A37-73A4-4356-97DB-6DC29B8B0E3D](https://github.com/APPSCHOOL3-iOS/final-yedi/assets/72439620/b8500fbb-58a9-4fff-89a7-8eb4b36279ff)

![simulator_screenshot_952B9506-FB01-419B-9311-FE2D0073EDD2](https://github.com/APPSCHOOL3-iOS/final-yedi/assets/72439620/4858eb06-87ae-4701-875b-11e83a284650)
