### PR TITLE
like button and likedPostListView connection, firestore connection

### DIFF
--- a/YeDi/YeDi.xcodeproj/project.pbxproj
+++ b/YeDi/YeDi.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		097EAD332AD03FC70037B848 /* CMLikedPostListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 097EAD322AD03FC70037B848 /* CMLikedPostListViewModel.swift */; };
+		097EAD352AD040CA0037B848 /* CMHomeCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 097EAD342AD040CA0037B848 /* CMHomeCellViewModel.swift */; };
 		1D12F9A32AC5569F001219E8 /* DMEditPostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D12F9A22AC5569F001219E8 /* DMEditPostView.swift */; };
 		1D9067172AC150D60028A660 /* DmDesignerModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D9067162AC150D60028A660 /* DmDesignerModels.swift */; };
 		1D9067192AC151A80028A660 /* DMAsyncImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D9067182AC151A80028A660 /* DMAsyncImage.swift */; };
@@ -102,6 +104,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		097EAD322AD03FC70037B848 /* CMLikedPostListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMLikedPostListViewModel.swift; sourceTree = "<group>"; };
+		097EAD342AD040CA0037B848 /* CMHomeCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMHomeCellViewModel.swift; sourceTree = "<group>"; };
 		1D12F9A22AC5569F001219E8 /* DMEditPostView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DMEditPostView.swift; sourceTree = "<group>"; };
 		1D9067162AC150D60028A660 /* DmDesignerModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DmDesignerModels.swift; sourceTree = "<group>"; };
 		1D9067182AC151A80028A660 /* DMAsyncImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DMAsyncImage.swift; sourceTree = "<group>"; };
@@ -316,6 +320,8 @@
 				3BCF2C382ACD4247009C18C2 /* PostDetailViewModel.swift */,
 				3BCF2C392ACD4247009C18C2 /* CMPostViewModel.swift */,
 				2F0A21902ACE753F0070CA42 /* CMProfileViewModel.swift */,
+				097EAD342AD040CA0037B848 /* CMHomeCellViewModel.swift */,
+				097EAD322AD03FC70037B848 /* CMLikedPostListViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -672,6 +678,7 @@
 				3BCF2C802ACD4248009C18C2 /* CMHomeView.swift in Sources */,
 				3BCF2C272ACD3E73009C18C2 /* CommonBubble.swift in Sources */,
 				3BCF2C842ACD4248009C18C2 /* CMMainChattingView.swift in Sources */,
+				097EAD352AD040CA0037B848 /* CMHomeCellViewModel.swift in Sources */,
 				639DB6842AC11B3B002692E5 /* DMReservationView.swift in Sources */,
 				3BCF2C292ACD3E73009C18C2 /* BoardBubbleCell.swift in Sources */,
 				3BCF2C852ACD4248009C18C2 /* ClientMainTabView.swift in Sources */,
@@ -695,6 +702,7 @@
 				96CBD4022AC3B0250055CC7F /* ReservationDetail.swift in Sources */,
 				96F637DF2AC2BCFD00EF74FF /* ReservationCellView.swift in Sources */,
 				1D9067172AC150D60028A660 /* DmDesignerModels.swift in Sources */,
+				097EAD332AD03FC70037B848 /* CMLikedPostListViewModel.swift in Sources */,
 				3BAB00F12ACD948C009053A4 /* DMExpandableText.swift in Sources */,
 				1D12F9A32AC5569F001219E8 /* DMEditPostView.swift in Sources */,
 				3BCF2C332ACD3F6A009C18C2 /* ChattingViewModel.swift in Sources */,

--- a/YeDi/YeDi/Client/View/CMHome/CMHomeCell.swift
+++ b/YeDi/YeDi/Client/View/CMHome/CMHomeCell.swift
@@ -6,14 +6,16 @@
 //
 
 import SwiftUI
+import Firebase
+import FirebaseFirestore
 
 struct CMHomeCell: View {
     var post: Post
+    @EnvironmentObject var userAuth: UserAuth
+    @StateObject private var viewModel = CMHomeCellViewModel()
     
     /// 이미지의 수를 판단할 수 있는 변수
     @State private var selectedImageIndex: Int = 0
-    /// 찜 버튼을 눌렀는지 판단할 수 있는 변수
-    @State private var isLiked: Bool = false
     /// 텍스트 수가 지정된 수를 넘었는지 확인할 수 있는 변수
     @State private var shouldShowMoreText: Bool = false
     /// 이미지를 두 번 연속 눌렀을 때 나오는 하트 이미지 변수
@@ -21,7 +23,7 @@ struct CMHomeCell: View {
     
     var body: some View {
         VStack {
-            // MARK: Post Header
+            // MARK: - Post Header
             HStack {
                 // 디자이너 프로필 이미지
                 Image(systemName: "person.circle.fill")
@@ -38,21 +40,20 @@ struct CMHomeCell: View {
             }
             .padding(.horizontal)
             
-            // MARK: Post Image
+            // MARK: - Post Image
             // 업로드한 이미지의 수가 1장일 경우와 1장 이상일 경우 분리
             // 1장의 경우는 단순히 이미지를 불러오고
             // 1장 이상일 경우에는 TabView를 이용하여 사진을 넘길 수 있음
             if post.photos.count == 1 {
-                // TODO: 이미지 누르면 DetailVeiw로 이동
-                // 이 주석 아래에 있는 4개의 주석을 풀고 디테일 뷰에서 imageURL 받기
                 NavigationLink(destination: CMFeedDetailView(post: post)) {
                     DMAsyncImage(url: post.photos[0].imageURL, placeholder: Image(systemName: "photo"))
                         .frame(width: 360, height: 360)
                         .aspectRatio(contentMode: .fit)
                         .cornerRadius(8)
                         .onTapGesture(count: 2) { // 이미지를 2번 연속 눌렀을 때
-                            isLiked = true
+                            viewModel.isLiked = true
                             showHeartImage = true
+                            viewModel.likePost(forClientID: userAuth.currentClientID ?? "", post: post)
                             DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
                                 showHeartImage = false
                             }
@@ -62,30 +63,31 @@ struct CMHomeCell: View {
                 TabView(selection: $selectedImageIndex) {
                     ForEach(0..<post.photos.count, id: \.self) { index in
                         NavigationLink(destination: CMFeedDetailView(post: post)) {
-                        DMAsyncImage(url: post.photos[index].imageURL, placeholder: Image(systemName: "photo"))
-                            .frame(width: 360, height: 360)
-                            .aspectRatio(contentMode:.fit)
-                            .cornerRadius(8)
-                            .tag(index)
-                            .overlay( // 현재 이미지가 총 이미지 중에서 몇 번째인지를 나타냄
-                                ZStack {
-                                    Text("\(selectedImageIndex + 1)/\(post.photos.count)")
-                                        .foregroundStyle(.white)
-                                        .padding(.horizontal, 15)
-                                        .padding(.vertical, 7)
-                                        .background {
-                                            Capsule(style: .continuous)
-                                                .foregroundStyle(.black.opacity(0.5))
-                                        }
-                                        .padding(10)
-                                }
-                                    .frame(maxWidth: .infinity, alignment: .topTrailing),alignment: .topTrailing
-                            )
+                            DMAsyncImage(url: post.photos[index].imageURL, placeholder: Image(systemName: "photo"))
+                                .frame(width: 360, height: 360)
+                                .aspectRatio(contentMode:.fit)
+                                .cornerRadius(8)
+                                .tag(index)
+                                .overlay( // 현재 이미지가 총 이미지 중에서 몇 번째인지를 나타냄
+                                    ZStack {
+                                        Text("\(selectedImageIndex + 1)/\(post.photos.count)")
+                                            .foregroundStyle(.white)
+                                            .padding(.horizontal, 15)
+                                            .padding(.vertical, 7)
+                                            .background {
+                                                Capsule(style: .continuous)
+                                                    .foregroundStyle(.black.opacity(0.5))
+                                            }
+                                            .padding(10)
+                                    }
+                                        .frame(maxWidth: .infinity, alignment: .topTrailing),alignment: .topTrailing
+                                )
                         }
                     }
                     .onTapGesture(count: 2) { // 이미지를 2번 연속 눌렀을 때
-                        isLiked = true
+                        viewModel.isLiked = true
                         showHeartImage = true
+                        viewModel.likePost(forClientID: userAuth.currentClientID ?? "", post: post)
                         DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
                             showHeartImage = false
                         }
@@ -96,19 +98,18 @@ struct CMHomeCell: View {
                 .padding(.horizontal)
             }
             
-            // MARK: Post Button
+            // MARK: - Post Button
             HStack {
                 // 게시글 찜 Button
-                // 계획) 버튼을 누르면 고객의 찜한 게시물 목록에 저장
-                // 질문) 하트 모양이 단순히 좋아요 느낌으로 다가오는 느낌이 있는데 변경이 필요할지?
                 Button(action: {
-                    isLiked.toggle()
+                    viewModel.isLiked.toggle()
+                    viewModel.likePost(forClientID: userAuth.currentClientID ?? "", post: post)
                 }, label: {
-                    Image(systemName: isLiked ? "heart.fill" : "heart")
+                    Image(systemName: viewModel.isLiked ? "heart.fill" : "heart")
                         .resizable()
                         .aspectRatio(contentMode: .fit)
                         .frame(width: 25, height: 25)
-                        .foregroundStyle(isLiked ? .red : .black)
+                        .foregroundStyle(viewModel.isLiked ? .red : .black)
                 })
                 Spacer()
                 // 상담하기 Button
@@ -126,7 +127,7 @@ struct CMHomeCell: View {
             }
             .padding(.horizontal)
             
-            // MARK: Post Description
+            // MARK: - Post Description
             // 게시글의 텍스트 제한이 없기 때문에 게시글이 방대해질 경우를 대비하여 더보기 설정
             HStack {
                 if shouldShowMoreText || post.description?.count ?? 0 <= 60 {
@@ -156,6 +157,11 @@ struct CMHomeCell: View {
                 }
             }
         )
+        .onAppear {
+            if let currentClientID = userAuth.currentClientID {
+                viewModel.checkIfLiked(forClientID: currentClientID, post: post)
+            }
+        }
     }
 }
 

--- a/YeDi/YeDi/Client/ViewModel/CMHomeCellViewModel.swift
+++ b/YeDi/YeDi/Client/ViewModel/CMHomeCellViewModel.swift
@@ -1,0 +1,87 @@
+//
+//  CMHomeCellViewModel.swift
+//  YeDi
+//
+//  Created by Jaehui Yu on 10/6/23.
+//
+
+import SwiftUI
+import Firebase
+import FirebaseFirestore
+
+class CMHomeCellViewModel: ObservableObject {
+    @Published var isLiked: Bool = false
+    
+    func checkIfLiked(forClientID clientID: String, post: Post) {
+        let db = Firestore.firestore()
+        
+        db.collection("likedPosts")
+            .whereField("clientID", isEqualTo: clientID)
+            .whereField("postID", isEqualTo: post.id ?? "")
+            .getDocuments { [weak self] snapshot, error in
+                guard let self = self else { return }
+                
+                if let error = error {
+                    print("Error checking liked post: \(error)")
+                } else {
+                    if (snapshot?.documents.first) != nil {
+                        // Firestore에서 해당 게시물을 찜되어 있는 경우
+                        DispatchQueue.main.async {
+                            self.isLiked = true
+                        }
+                    } else {
+                        // Firestore에서 해당 게시물을 찜되어 있지 않은 경우
+                        DispatchQueue.main.async {
+                            self.isLiked = false
+                        }
+                    }
+                }
+            }
+    }
+    
+    func likePost(forClientID clientID: String, post: Post) {
+        let db = Firestore.firestore()
+        let likeCollection = db.collection("likedPosts")
+        
+        // 게시물 정보를 Firestore에 추가
+        let likedPostData: [String: Any] = [
+            "clientID": clientID,
+            "postID": post.id ?? "",
+            "isLiked": isLiked,
+            "timestamp": FieldValue.serverTimestamp()
+        ]
+        
+        likeCollection.addDocument(data: likedPostData) { error in
+            if let error = error {
+                print("Error liking post: \(error)")
+            } else {
+                print("Post liked successfully.")
+                
+                if !self.isLiked {
+                    // isLiked가 false인 경우, 해당 게시물을 Firestore에서 삭제합니다.
+                    self.deleteFromFirestore(forClientID: clientID, post: post)
+                }
+            }
+        }
+    }
+    
+    private func deleteFromFirestore(forClientID clientID: String, post: Post) {
+        let db = Firestore.firestore()
+        
+        db.collection("likedPosts")
+            .whereField("clientID", isEqualTo: clientID)
+            .whereField("postID", isEqualTo: post.id ?? "")
+            .getDocuments { snapshot, error in
+                if let error = error {
+                    print("Error deleting liked post: \(error)")
+                } else {
+                    for document in snapshot?.documents ?? [] {
+                        document.reference.delete()
+                    }
+                    
+                    print("Post unliked successfully.")
+                }
+            }
+    }
+}
+

--- a/YeDi/YeDi/Client/ViewModel/CMLikedPostListViewModel.swift
+++ b/YeDi/YeDi/Client/ViewModel/CMLikedPostListViewModel.swift
@@ -1,0 +1,65 @@
+//
+//  CMLikedPostListViewModel.swift
+//  YeDi
+//
+//  Created by Jaehui Yu on 10/6/23.
+//
+
+import SwiftUI
+import FirebaseFirestore
+
+class CMLikePostListViewModel: ObservableObject {
+    @Published var likedPosts: [Post] = []
+    
+    func fetchLikedPosts(forClientID clientID: String) {
+        let db = Firestore.firestore()
+        
+        let likedPostsCollection = db.collection("likedPosts")
+        likedPostsCollection
+            .whereField("clientID", isEqualTo: clientID)
+            .getDocuments { [weak self] snapshot, error in
+                guard let self = self else { return }
+                
+                if let error = error {
+                    print("Error fetching liked posts: \(error)")
+                    return
+                }
+                
+                var likedPostIDs: [String] = []
+                
+                for document in snapshot?.documents ?? [] {
+                    if let postID = document["postID"] as? String {
+                        likedPostIDs.append(postID)
+                    }
+                }
+                
+                guard !likedPostIDs.isEmpty else {
+                    self.likedPosts.removeAll()
+                    return
+                }
+                
+                let postsCollection = db.collection("posts")
+                postsCollection
+                    .whereField(FieldPath.documentID(), in: likedPostIDs)
+                    .getDocuments { snapshot, error in
+                        if let error = error {
+                            print("Error fetching liked posts: \(error)")
+                            return
+                        }
+                        
+                        var likedPosts: [Post] = []
+                        
+                        for document in snapshot?.documents ?? [] {
+                            if let post = try? document.data(as: Post.self) {
+                                likedPosts.append(post)
+                            }
+                        }
+                        
+                        DispatchQueue.main.async {
+                            self.likedPosts = likedPosts
+                        }
+                    }
+            }
+    }
+}
+


### PR DESCRIPTION
게시물 찜 버튼 클릭시
1) 마이페이지의 찜한 게시물에 추가
2) firestore에 likedPosts로 저장

다시 클릭할 경우
마이페이지의 찜한 게시물과, firestore에서 전부 제거

찜한 게시물에서 이미지 클릭시
게시물 디테일 뷰로 이동