### PR TITLE
Feat: 컬러 에셋 세팅 & 리뷰 작성시 키워드 리뷰 선택 가능하도록 구현 완료

### DIFF
--- a/YeDi/YeDi.xcodeproj/project.pbxproj
+++ b/YeDi/YeDi.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		2F0A21932ACFD4B00070CA42 /* Review.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0A21922ACFD4B00070CA42 /* Review.swift */; };
 		2F0A21952ACFD8950070CA42 /* CMReviewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0A21942ACFD8950070CA42 /* CMReviewViewModel.swift */; };
 		2F0CAF7B2AD143D700646C00 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 2F0CAF7A2AD143D700646C00 /* GoogleService-Info.plist */; };
+		2F45A1282AD2739C005018A5 /* Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F45A1272AD2739C005018A5 /* Color.swift */; };
 		3B517D482ACE46420082E2F6 /* ConsultationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B517D472ACE46420082E2F6 /* ConsultationViewModel.swift */; };
 		3BAB00EB2ACD92D6009053A4 /* DMAccount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BAB00EA2ACD92D5009053A4 /* DMAccount.swift */; };
 		3BAB00F12ACD948C009053A4 /* DMExpandableText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BAB00F02ACD948B009053A4 /* DMExpandableText.swift */; };
@@ -119,6 +120,7 @@
 		2F0A21922ACFD4B00070CA42 /* Review.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Review.swift; sourceTree = "<group>"; };
 		2F0A21942ACFD8950070CA42 /* CMReviewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMReviewViewModel.swift; sourceTree = "<group>"; };
 		2F0CAF7A2AD143D700646C00 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
+		2F45A1272AD2739C005018A5 /* Color.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Color.swift; sourceTree = "<group>"; };
 		3B517D472ACE46420082E2F6 /* ConsultationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsultationViewModel.swift; sourceTree = "<group>"; };
 		3BAB00EA2ACD92D5009053A4 /* DMAccount.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DMAccount.swift; sourceTree = "<group>"; };
 		3BAB00F02ACD948B009053A4 /* DMExpandableText.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DMExpandableText.swift; sourceTree = "<group>"; };
@@ -218,6 +220,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		2F45A1262AD27388005018A5 /* Extension */ = {
+			isa = PBXGroup;
+			children = (
+				2F45A1272AD2739C005018A5 /* Color.swift */,
+			);
+			path = Extension;
+			sourceTree = "<group>";
+		};
 		2FA7FC322ACE47480027BDEE /* CMSearch */ = {
 			isa = PBXGroup;
 			children = (
@@ -231,6 +241,7 @@
 		3BCF2C032ACD3E72009C18C2 /* Shared */ = {
 			isa = PBXGroup;
 			children = (
+				2F45A1262AD27388005018A5 /* Extension */,
 				3BCF2C042ACD3E72009C18C2 /* ViewModel */,
 				3BCF2C092ACD3E72009C18C2 /* Model */,
 				3BCF2C122ACD3E72009C18C2 /* View */,
@@ -688,6 +699,7 @@
 			files = (
 				3BCF2C8E2ACD4248009C18C2 /* CMNotificationView.swift in Sources */,
 				3BCF2C2C2ACD3E73009C18C2 /* BubbleCell.swift in Sources */,
+				2F45A1282AD2739C005018A5 /* Color.swift in Sources */,
 				3BCF2C812ACD4248009C18C2 /* CMFollowingPostView.swift in Sources */,
 				3BCF2C2D2ACD3E73009C18C2 /* TempPhotoPickerView.swift in Sources */,
 				3BCF2C2E2ACD3E73009C18C2 /* ChatUtilityMenuView.swift in Sources */,

--- a/YeDi/YeDi/Assets.xcassets/mainColor.colorset/Contents.json
+++ b/YeDi/YeDi/Assets.xcassets/mainColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.000",
+          "green" : "0.000",
+          "red" : "0.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.000",
+          "green" : "0.000",
+          "red" : "0.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/YeDi/YeDi/Assets.xcassets/pointColor.colorset/Contents.json
+++ b/YeDi/YeDi/Assets.xcassets/pointColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.541",
+          "green" : "0.824",
+          "red" : "0.416"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.541",
+          "green" : "0.824",
+          "red" : "0.416"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/YeDi/YeDi/Assets.xcassets/subColor.colorset/Contents.json
+++ b/YeDi/YeDi/Assets.xcassets/subColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.529",
+          "green" : "0.278",
+          "red" : "0.922"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.529",
+          "green" : "0.278",
+          "red" : "0.922"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/YeDi/YeDi/Client/Model/Keyword.swift
+++ b/YeDi/YeDi/Client/Model/Keyword.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct Keyword: Identifiable, Codable {
+struct Keyword: Identifiable, Equatable, Codable {
     var id: String = UUID().uuidString
     var keyword: String
     var isSelected: Bool

--- a/YeDi/YeDi/Client/View/CMReview/CMReviewCreateKeywordsView.swift
+++ b/YeDi/YeDi/Client/View/CMReview/CMReviewCreateKeywordsView.swift
@@ -8,7 +8,10 @@
 import SwiftUI
 
 struct CMReviewCreateKeywordsView: View {
-    @Binding var selectedKeywords: [String]
+    @Binding var selectedKeywords: [Keyword]
+    
+    @State private var displayedKeywords: [Keyword] = keywords
+    @State private var isShowingAlert: Bool = false
     
     let keywordCategories: [String] = KeywordCategory.allCases.map { $0.rawValue }
     
@@ -23,15 +26,33 @@ struct CMReviewCreateKeywordsView: View {
                             ForEach(0..<keywords.count, id: \.self) { index in
                                 if keywords[index].category.rawValue == category {
                                     Button(action: {
-                                        selectedKeywords.append(keywords[index].keyword)
+                                        selectKeyword(index: index)
                                     }) {
-                                        Text("\(keywords[index].keyword)")
-                                            .foregroundStyle(keywords[index].isSelected ? .red : .black)
-                                            .padding(10)
-                                            .background(
-                                                RoundedRectangle(cornerRadius: 2)
-                                                    .stroke(Color(white: 0.9), lineWidth: 1)
-                                            )
+                                        if displayedKeywords[index].isSelected {
+                                            Text("\(keywords[index].keyword)")
+                                                .foregroundStyle(.white)
+                                                .padding(10)
+                                                .background(
+                                                    RoundedRectangle(cornerRadius: 5)
+                                                        .fill(Color.subColor)
+                                                )
+                                        } else {
+                                            Text("\(keywords[index].keyword)")
+                                                .foregroundStyle(.black)
+                                                .padding(10)
+                                                .background(
+                                                    RoundedRectangle(cornerRadius: 5)
+                                                        .stroke(Color(white: 0.9), lineWidth: 1)
+                                                )
+                                        }
+                                    }
+                                    .alert("최대 5개의 키워드 리뷰만 선택 가능합니다.", isPresented: $isShowingAlert) {
+                                        Button(role: .cancel) {
+                                            isShowingAlert.toggle()
+                                        } label: {
+                                            Text("확인")
+                                        }
+
                                     }
                                 }
                             }
@@ -43,15 +64,37 @@ struct CMReviewCreateKeywordsView: View {
             .padding(EdgeInsets(top: 0, leading: 10, bottom: 40, trailing: 0))
             .scrollIndicators(.never)
         } header: {
-            HStack {
-                Text("어떤 점이 좋았나요?")
-                    .padding(.leading)
-                    .fontWeight(.semibold)
-                Spacer()
+            VStack {
+                HStack {
+                    Text("어떤 점이 좋았나요?")
+                        .padding(.leading)
+                        .fontWeight(.semibold)
+                    Spacer()
+                }
+                HStack {
+                    Text("최대 5개까지 선택할 수 있어요.")
+                        .padding(.leading)
+                        .foregroundStyle(.gray)
+                    Spacer()
+                }
             }
             Divider()
                 .frame(width: 360)
                 .padding(.bottom, 10)
+        }
+    }
+    
+    func selectKeyword(index: Int) {
+        if displayedKeywords[index].isSelected {
+            selectedKeywords.removeAll(where: { $0 == keywords[index] })
+            displayedKeywords[index].isSelected.toggle()
+        } else {
+            if selectedKeywords.count >= 5 {
+                isShowingAlert.toggle()
+            } else {
+                selectedKeywords.append(keywords[index])
+                displayedKeywords[index].isSelected.toggle()
+            }
         }
     }
 }

--- a/YeDi/YeDi/Client/View/CMReview/CMReviewCreateMainView.swift
+++ b/YeDi/YeDi/Client/View/CMReview/CMReviewCreateMainView.swift
@@ -18,8 +18,9 @@ struct CMReviewCreateMainView: View {
     
     @State private var selectedPhoto: PhotosPickerItem? = nil
     @State private var selectedPhotoData: [Data] = []
+    @State private var selectedPhotoURLs: [String] = []
     
-    @State private var selectedKeywords: [String] = []
+    @State private var selectedKeywords: [Keyword] = []
     @State private var designerScore: Int = 0
     @State private var reviewContent: String = ""
     
@@ -75,10 +76,10 @@ struct CMReviewCreateMainView: View {
                     id: UUID().uuidString,
                     reviewer: userAuth.currentClientID ?? "",
                     date: writtenDate,
-                    keywordReviews: [],
+                    keywordReviews: selectedKeywords,
                     designerScore: designerScore,
                     content: reviewContent,
-                    imageURLStrings: [],
+                    imageURLStrings: selectedPhotoURLs,
                     reservationId: UUID().uuidString,
                     style: "펌, 염색",
                     designer: UUID().uuidString

--- a/YeDi/YeDi/Shared/Extension/Color.swift
+++ b/YeDi/YeDi/Shared/Extension/Color.swift
@@ -1,0 +1,14 @@
+//
+//  Color.swift
+//  YeDi
+//
+//  Created by 박채영 on 2023/10/08.
+//
+
+import SwiftUI
+
+extension Color {
+    static let mainColor = Color("mainColor")
+    static let subColor = Color("subColor")
+    static let pointColor = Color("pointColor")
+}


### PR DESCRIPTION
- mainColor, subColor, pointColor에 대한 컬러 에셋 세팅 완료
  - .mainColor와 같이 접근하여 사용 가능
- 리뷰 작성시 최대 5개의 키워드 리뷰 선택 가능하도록 구현 완료
  - 5개를 초과하여 선택할 경우, 경고 alert를 띄워서 5개 이내로 선택하도록 안내
  - 아래 이미지 참고
  ![스크린샷 2023-10-08 오후 3 29 54](https://github.com/APPSCHOOL3-iOS/final-yedi/assets/72439620/bb9efb0e-48b1-4471-8276-0e912b390213)
