### PR TITLE
Fix: 회원가입 시 바로 홈화면으로 이동하는 이슈 및 고객, 디자이너 구분없이 이메일 중복체크 허용되고 로그인이 되는 이슈 해결

### DIFF
--- a/YeDi/YeDi.xcodeproj/project.pbxproj
+++ b/YeDi/YeDi.xcodeproj/project.pbxproj
@@ -85,7 +85,6 @@
 		3BCF2C8E2ACD4248009C18C2 /* CMNotificationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BCF2C662ACD4248009C18C2 /* CMNotificationView.swift */; };
 		3BCF2C8F2ACD4248009C18C2 /* CMSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BCF2C672ACD4248009C18C2 /* CMSettingsView.swift */; };
 		3BCF2C902ACD4248009C18C2 /* CMProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BCF2C682ACD4248009C18C2 /* CMProfileView.swift */; };
-		6360595D2AD691DD00F1BB6D /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 6360595C2AD691DC00F1BB6D /* GoogleService-Info.plist */; };
 		639DB6372AC10E44002692E5 /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 639DB6362AC10E44002692E5 /* FirebaseAuth */; };
 		639DB63D2AC10E44002692E5 /* FirebaseDatabase in Frameworks */ = {isa = PBXBuildFile; productRef = 639DB63C2AC10E44002692E5 /* FirebaseDatabase */; };
 		639DB63F2AC10E44002692E5 /* FirebaseDatabaseSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 639DB63E2AC10E44002692E5 /* FirebaseDatabaseSwift */; };
@@ -113,6 +112,7 @@
 		DC7695482AD0888800D2FB69 /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC7695452AD0888800D2FB69 /* LoginView.swift */; };
 		DC76954F2AD088DB00D2FB69 /* AuthViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC76954E2AD088DB00D2FB69 /* AuthViewModel.swift */; };
 		DC7695532AD08A3600D2FB69 /* RegisterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC7695522AD08A3600D2FB69 /* RegisterView.swift */; };
+		DC7695802AD8E49700D2FB69 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = DC76957F2AD8E49700D2FB69 /* GoogleService-Info.plist */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -194,7 +194,6 @@
 		3BCF2C662ACD4248009C18C2 /* CMNotificationView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CMNotificationView.swift; sourceTree = "<group>"; };
 		3BCF2C672ACD4248009C18C2 /* CMSettingsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CMSettingsView.swift; sourceTree = "<group>"; };
 		3BCF2C682ACD4248009C18C2 /* CMProfileView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CMProfileView.swift; sourceTree = "<group>"; };
-		6360595C2AD691DC00F1BB6D /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		639DB6602AC10F13002692E5 /* DesignerMainTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignerMainTabView.swift; sourceTree = "<group>"; };
 		639DB6792AC11AC2002692E5 /* DMReviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DMReviewView.swift; sourceTree = "<group>"; };
 		639DB67D2AC11AF5002692E5 /* DMProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DMProfileView.swift; sourceTree = "<group>"; };
@@ -217,6 +216,7 @@
 		DC7695452AD0888800D2FB69 /* LoginView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
 		DC76954E2AD088DB00D2FB69 /* AuthViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthViewModel.swift; sourceTree = "<group>"; };
 		DC7695522AD08A3600D2FB69 /* RegisterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterView.swift; sourceTree = "<group>"; };
+		DC76957F2AD8E49700D2FB69 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -594,7 +594,7 @@
 		63CD89AF2ABD85C300E70A56 /* YeDi */ = {
 			isa = PBXGroup;
 			children = (
-				6360595C2AD691DC00F1BB6D /* GoogleService-Info.plist */,
+				DC76957F2AD8E49700D2FB69 /* GoogleService-Info.plist */,
 				3BCF2C032ACD3E72009C18C2 /* Shared */,
 				3BCF2C362ACD4247009C18C2 /* Client */,
 				639DB6282AC10DED002692E5 /* Designer */,
@@ -726,7 +726,7 @@
 			files = (
 				63CD89B82ABD85C500E70A56 /* Preview Assets.xcassets in Resources */,
 				63CD89B52ABD85C500E70A56 /* Assets.xcassets in Resources */,
-				6360595D2AD691DD00F1BB6D /* GoogleService-Info.plist in Resources */,
+				DC7695802AD8E49700D2FB69 /* GoogleService-Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/YeDi/YeDi/Shared/ViewModel/Auth/AuthViewModel.swift
+++ b/YeDi/YeDi/Shared/ViewModel/Auth/AuthViewModel.swift
@@ -18,6 +18,7 @@ final class UserAuth: ObservableObject {
     @Published var currentDesignerID: String?
     @Published var userType: UserType?
     @Published var userSession: FirebaseAuth.User?
+    @Published var isCheckEmailAvailability: Bool = false
     
     private let auth = Auth.auth()
     private let storeService = Firestore.firestore()
@@ -70,9 +71,6 @@ final class UserAuth: ObservableObject {
                 completion(false)
                 return
             }
-            self.userSession = user
-            self.userType = type
-            self.saveUserTypeinUserDefaults(type.rawValue)
             
             /// user type에 따라서 각 고객, 디자이너 정보 가져오기
             let collectionName = type.rawValue + "s"
@@ -91,129 +89,152 @@ final class UserAuth: ObservableObject {
                     return
                 }
                 
-                switch self.userType {
-                case .client:
-                    if let name = userData["name"] as? String,
-                       let email = userData["email"] as? String{
-                        print("Name:", name)
-                        print("Email:", email)
-                        
+                if let name = userData["name"] as? String,
+                   let email = userData["email"] as? String{
+                    print("Name:", name)
+                    print("Email:", email)
+                    
+                    switch self.userType {
+                    case .client:
                         self.currentClientID = user.uid
-                        completion(true)
-                    } else {
-                        print("Invalid user data")
-                        completion(false)
-                    }
-                case .designer:
-                    if let userData = documents.first?.data() {
-                        // 디자이너 정보 업데이트
-                        if let name = userData["name"] as? String,
-                           let email = userData["email"] as? String{
-                            print("Name:", name)
-                            print("Email:", email)
-                            
-                            self.currentDesignerID = user.uid
-                            completion(true)
-                        } else {
-                            print("Invalid user data")
-                            completion(false)
-                        }
-                    } else {
-                        print("User data not found")
-                        completion(false)
+                    case .designer:
+                        self.currentDesignerID = user.uid
+                    case .none:
+                        return
                     }
                     
-                case .none:
-                    return
+                    self.userSession = user
+                    self.userType = type
+                    self.saveUserTypeinUserDefaults(type.rawValue)
+                    
+                    completion(true)
+                } else {
+                    print("Invalid user data")
+                    completion(false)
                 }
             }
         }
     }
     
-    func registerClient(client: Client, password: String) {
+    func registerClient(client: Client, password: String, completion: @escaping (Bool) -> Void) {
         auth.createUser(withEmail: client.email, password: password) { result, error in
             if let error = error {
+                completion(false)
                 print("DEBUG: Error registering new user: \(error.localizedDescription)")
                 return
+            } else {
+                completion(true)
+                
+                guard let user = result?.user else { return }
+                print("DEBUG: Registered User successfully")
+                
+                let data: [String: Any] = [
+                    "id": user.uid,
+                    "name": client.name,
+                    "email": client.email,
+                    "profileImageURLString": client.profileImageURLString,
+                    "phoneNumber": client.phoneNumber,
+                    "gender": client.gender,
+                    "birthDate": client.birthDate,
+                    "favoriteStyle": client.favoriteStyle,
+                    "chatRooms": client.chatRooms
+                ]
+                
+                self.storeService.collection("clients")
+                    .document(user.uid)
+                    .setData(data, merge: true)
             }
-
-            guard let user = result?.user else { return }
-            self.userSession = user
-
-            print("DEBUG: Registered User successfully")
-
-            let data: [String: Any] = [
-                "id": user.uid,
-                "name": client.name,
-                "email": client.email,
-                "profileImageURLString": client.profileImageURLString,
-                "phoneNumber": client.phoneNumber,
-                "gender": client.gender,
-                "birthDate": client.birthDate,
-                "favoriteStyle": client.favoriteStyle,
-                "chatRooms": client.chatRooms
-            ]
-
-            self.storeService.collection("clients")
-                .document(user.uid)
-                .setData(data, merge: true)
         }
     }
     
-    func registerDesigner(designer: Designer, password: String) {
+    func registerDesigner(designer: Designer, password: String, completion: @escaping (Bool) -> Void) {
         auth.createUser(withEmail: designer.email, password: password) { result, error in
             if let error = error {
+                completion(false)
                 print("DEBUG: Error registering new user: \(error.localizedDescription)")
                 return
+            } else {
+                completion(true)
+                
+                guard let user = result?.user else { return }
+                print("DEBUG: Registered User successfully")
+                
+                let data: [String: Any] = [
+                    "id": user.uid,
+                    "name": designer.name,
+                    "email": designer.email,
+                    "imageURLString": designer.imageURLString ?? "",
+                    "phoneNumber": designer.phoneNumber,
+                    "description": designer.description ?? "",
+                    "designerScore": designer.designerScore,
+                    "reviewCount": designer.reviewCount,
+                    "followerCount": designer.followerCount,
+                    "skill": designer.skill,
+                    "chatRooms": designer.chatRooms,
+                    "birthDate": designer.birthDate,
+                    "gender": designer.gender,
+                    "rank": designer.rank.rawValue,
+                    "designerUID": user.uid
+                ]
+                
+                self.storeService.collection("designers")
+                    .document(user.uid)
+                    .setData(data, merge: true)
             }
-
-            guard let user = result?.user else { return }
-            self.userSession = user
-
-            print("DEBUG: Registered User successfully")
-
-            let data: [String: Any] = [
-                "id": user.uid,
-                "name": designer.name,
-                "email": designer.email,
-                "imageURLString": designer.imageURLString ?? "",
-                "phoneNumber": designer.phoneNumber,
-                "description": designer.description ?? "",
-                "designerScore": designer.designerScore,
-                "reviewCount": designer.reviewCount,
-                "followerCount": designer.followerCount,
-                "skill": designer.skill,
-                "chatRooms": designer.chatRooms,
-                "birthDate": designer.birthDate,
-                "gender": designer.gender,
-                "rank": designer.rank.rawValue,
-                "designerUID": user.uid
-            ]
-
-            self.storeService.collection("designers")
-                .document(user.uid)
-                .setData(data, merge: true)
         }
     }
     
-    func checkEmailAvailability(_ email: String, _ userType: UserType, completion: @escaping (Bool) -> Void) {
-        let collectionName = userType.rawValue + "s"
-        
-        self.storeService.collection(collectionName).whereField("email", isEqualTo: email).getDocuments { snapshot, error in
-            if let error = error {
-                print("Firestore query error:", error.localizedDescription)
-                completion(false)
-                return
-            }
-            
-            if (snapshot?.documents.count) != 0 {
-                completion(true)
-            } else {
-                completion(false)
-            }
-        }
-        
-    }
+//    func checkEmailAvailability(_ email: String, userType collectionName: String, completion: @escaping (Bool) -> Void) {
+//        self.storeService.collection(collectionName).whereField("email", isEqualTo: email).getDocuments { snapshot, error in
+//            if let error = error {
+//                print("Firestore query error:", error.localizedDescription)
+//                completion(false)
+//                return
+//            }
+//            
+//            if (snapshot?.documents.count) != 0 {
+//                completion(true)
+//            } else {
+//                completion(false)
+//            }
+//        }
+//    }
+    
+//    func checkEmailAvailability(_ email: String, _ userType: UserType, completion: @escaping (Bool) -> Void) {
+//        let collectionName = userType.rawValue + "s"
+//        
+//        self.storeService.collection(collectionName).whereField("email", isEqualTo: email).getDocuments { snapshot, error in
+//            if let error = error {
+//                print("Firestore query error:", error.localizedDescription)
+//                completion(false)
+//                return
+//            }
+//            
+//            if (snapshot?.documents.count) != 0 {
+//                completion(true)
+//            } else {
+//                completion(false)
+//            }
+//        }
+//        
+//    }
+    
+//    func isAlreadySignUp(_ email: String, completion: @escaping (Bool) -> Void) {
+//        auth.fetchSignInMethods(forEmail: email) { signInMethods, error in
+//            if let error = error {
+//                let err = error as NSError
+//                
+//                switch err {
+//                case AuthErrorCode.emailAlreadyInUse:
+//                    print("================== auth error")
+//                    completion(false)
+//                default:
+//                    print("unknown error: \(err.localizedDescription)")
+//                }
+//            }
+//            completion(true)
+//        }
+//    }
     
     func signOut() {
         userSession = nil


### PR DESCRIPTION
- 회원가입 시 바로 고객, 디자이너 메인 홈 화면으로 이동하는 이슈 해결
- 고객, 디자이너 구분없이 이메일 중복체크시 허용이 되고, 로그인이 되는 이슈 해결
    - 기존 중복확인 버튼 삭제하고, 회원가입 버튼 클릭 시 이메일 중복체크까지 하도록 변경
    - 기존 중복확인 로직은 컬렉션에 접근하여 입력한 이메일 비교하는 로직이었는데, 현재는 회원가입 버튼 클릭 시 auth에서 이메일 비교하는 로직으로 변경

수정한 파일
- RegisterView
- AuthViewModel