### PR TITLE
HOTFIX: 회원가입 시 userSession이 저장되어 뷰 이동이 되지 않는 이슈 해결

### DIFF
--- a/YeDi/YeDi/Shared/ViewModel/Auth/AuthViewModel.swift
+++ b/YeDi/YeDi/Shared/ViewModel/Auth/AuthViewModel.swift
@@ -142,6 +142,8 @@ final class UserAuth: ObservableObject {
                 self.storeService.collection("clients")
                     .document(user.uid)
                     .setData(data, merge: true)
+                
+                self.userSession = nil
             }
         }
     }
@@ -178,6 +180,8 @@ final class UserAuth: ObservableObject {
                 self.storeService.collection("designers")
                     .document(user.uid)
                     .setData(data, merge: true)
+                
+                self.userSession = nil
             }
         }
     }


### PR DESCRIPTION
고객, 디자이너 회원가입 완료 후 빈 화면만 보였던 이슈
- 초기 화면은 user값이 nil이어야 하는데 회원가입 시 기입한 정보로 user를 저장시키면서 충돌이 발생했습니다.
- 회원가입 로직 마지막에 `self.userSession = nil`를 추가하여 초기 화면으로 돌아갈 수 있도록 수정하였습니다.