### PR TITLE
Fix: 로그인 상태 유지가 되지 않았던 이슈 해결

### DIFF
--- a/YeDi/YeDi/Shared/ViewModel/Auth/AuthViewModel.swift
+++ b/YeDi/YeDi/Shared/ViewModel/Auth/AuthViewModel.swift
@@ -25,10 +25,8 @@ final class UserAuth: ObservableObject {
     private let userDefaults: UserDefaults = UserDefaults.standard
     
     init() {
-        if isLogin {
-            fetchUserTypeinUserDefaults()
-            fetchUser()
-        }
+        fetchUserTypeinUserDefaults()
+        fetchUser()
     }
     
     func fetchUser() {
@@ -36,6 +34,7 @@ final class UserAuth: ObservableObject {
             if let user = user {
                 self?.userSession = user
                 self?.userType = self?.userType
+                self?.isLogin = true
                 
                 switch self?.userType {
                 case .client:


### PR DESCRIPTION
이슈
- `isLogin` 프로퍼티를 추가하면서 앱 재실행 시 값이 초기화되는 현상으로 인해 로그인 상태를 유지하지 못했습니다.

해결
- AuthViewModel `init()`에 `isLogin`로 분기 처리하던 로직 삭제
- `fetch()`에 `isLogin` 값 추가