### PR TITLE
HOTFIX: fireStore에 사용자 데이터가 없을 때 체크하는 로직 추가 및 변경

### DIFF
--- a/YeDi/YeDi/Shared/ViewModel/Auth/AuthViewModel.swift
+++ b/YeDi/YeDi/Shared/ViewModel/Auth/AuthViewModel.swift
@@ -48,8 +48,7 @@ final class UserAuth: ObservableObject {
                             return
                         }
                     } else {
-                        // 사용자 데이터가 서버에 없으면 사용자 정보 저장하지 않음
-                        self?.signOut() // 로그아웃 처리 예시
+                        self?.signOut()
                     }
                 }
             } else {


### PR DESCRIPTION
문제 상황
- 로그인 시 사용자 데이터를 `Auth.auth().addStateDidChangeListener`를 통해 저장을 시킵니다.
- 하지만 fireStore에 사용자 데이터가 없을 때도 이전에 저장되어 있던 데이터가 사라지지 않아 앱 실행에 문제가 되었습니다.

해결
- `addStateDidChangeListener` 로직에 fireStore에 사용자 데이터가 존재하는지 한 번 더 체크 후 사용자 데이터를 저장시키도록 로직을 변경하였습니다.