### PR TITLE
Fix: #141 이전 코드로 변경

### DIFF
--- a/YeDi/YeDi/Shared/ViewModel/Auth/AuthViewModel.swift
+++ b/YeDi/YeDi/Shared/ViewModel/Auth/AuthViewModel.swift
@@ -32,89 +32,64 @@ final class UserAuth: ObservableObject {
     func fetchUser() {
         auth.addStateDidChangeListener { [weak self] _, user in
             if let user = user {
-                self?.checkIfUserExistsInFirestore(user: user) { exists in
-                    if exists {
-                        // 사용자 데이터가 서버에 존재하면 사용자 정보 저장
-                        self?.userSession = user
-                        self?.userType = self?.userType
-                        self?.isLogin = true
-                        
-                        switch self?.userType {
-                        case .client:
-                            self?.currentClientID = user.uid
-                        case .designer:
-                            self?.currentDesignerID = user.uid
-                        case nil:
-                            return
-                        }
-                    } else {
-                        self?.signOut()
-                    }
+                self?.userSession = user
+                self?.userType = self?.userType
+                self?.isLogin = true
+                
+                switch self?.userType {
+                case .client:
+                    self?.currentClientID = user.uid
+                case .designer:
+                    self?.currentDesignerID = user.uid
+                case nil:
+                    return
                 }
             } else {
-                self?.isLogin = false
-                self?.userSession = nil
-                self?.currentClientID = nil
-                self?.currentDesignerID = nil
+                self?.resetUserInfo()
             }
         }
     }
     
-    func checkIfUserExistsInFirestore(user: User, completion: @escaping (Bool) -> Void) {
-        let clientCollection = storeService.collection("clients")
-        let designerCollection = storeService.collection("designers")
-        
-        // clients collection에서 사용자 데이터를 확인할 함수
-        func checkClientCollection(completion: @escaping (Bool) -> Void) {
-            clientCollection.document(user.uid).getDocument { document, error in
-                if let document = document, document.exists {
-                    // 사용자 데이터가 clients collection에 존재
-                    completion(true)
-                } else {
-                    completion(false)
-                }
-            }
-        }
-        
-        // designers collection에서 사용자 데이터를 확인할 함수
-        func checkDesignerCollection(completion: @escaping (Bool) -> Void) {
-            designerCollection.document(user.uid).getDocument { document, error in
-                if let document = document, document.exists {
-                    // 사용자 데이터가 designers collection에 존재
-                    completion(true)
-                } else {
-                    completion(false)
-                }
-            }
-        }
-        
-        // 두 컬렉션에서 사용자 데이터 확인
-        checkClientCollection { existsInClientCollection in
-            checkDesignerCollection { existsInDesignerCollection in
-                // 두 컬렉션 모두 사용자 데이터가 존재하면 completion(true) 호출
-                if existsInClientCollection && existsInDesignerCollection {
-                    completion(true)
-                } else {
-                    completion(false)
-                }
-            }
-        }
-    }
-    
-    func fetchUserTypeinUserDefaults() {
-        if let type = userDefaults.value(forKey: "UserType") {
-            let typeToString = String(describing: type)
-            self.userType = UserType(rawValue: typeToString)
-        }
-    }
-    
-    func saveUserTypeinUserDefaults(_ type: String) {
-        userDefaults.set(type, forKey: "UserType")
-    }
-    
-    func removeUserTypeinUserDefaults() {
-        userDefaults.removeObject(forKey: "UserType")
-    }
+//    func checkIfUserExistsInFirestore(user: User, completion: @escaping (Bool) -> Void) {
+//        let clientCollection = storeService.collection("clients")
+//        let designerCollection = storeService.collection("designers")
+//        
+//        // clients collection에서 사용자 데이터를 확인할 함수
+//        func checkClientCollection(completion: @escaping (Bool) -> Void) {
+//            clientCollection.document(user.uid).getDocument { document, error in
+//                if let document = document, document.exists {
+//                    // 사용자 데이터가 clients collection에 존재
+//                    completion(true)
+//                } else {
+//                    completion(false)
+//                }
+//            }
+//        }
+//        
+//        // designers collection에서 사용자 데이터를 확인할 함수
+//        func checkDesignerCollection(completion: @escaping (Bool) -> Void) {
+//            designerCollection.document(user.uid).getDocument { document, error in
+//                if let document = document, document.exists {
+//                    // 사용자 데이터가 designers collection에 존재
+//                    completion(true)
+//                } else {
+//                    completion(false)
+//                }
+//            }
+//        }
+//        
+//        // 두 컬렉션에서 사용자 데이터 확인
+//        checkClientCollection { existsInClientCollection in
+//            checkDesignerCollection { existsInDesignerCollection in
+//                // 두 컬렉션 모두 사용자 데이터가 존재하면 completion(true) 호출
+//                if existsInClientCollection && existsInDesignerCollection {
+//                    completion(true)
+//                } else {
+//                    completion(false)
+//                }
+//            }
+//        }
+//    }
     
     func signIn(_ email: String, _ password: String, _ type: UserType, _ completion: @escaping (Bool) -> Void) {
         auth.signIn(withEmail: email, password: password) { result, error in
@@ -325,5 +300,20 @@ final class UserAuth: ObservableObject {
         isLogin = false
         
         removeUserTypeinUserDefaults()
+    }
+    
+    func fetchUserTypeinUserDefaults() {
+        if let type = userDefaults.value(forKey: "UserType") {
+            let typeToString = String(describing: type)
+            self.userType = UserType(rawValue: typeToString)
+        }
+    }
+    
+    func saveUserTypeinUserDefaults(_ type: String) {
+        userDefaults.set(type, forKey: "UserType")
+    }
+    
+    func removeUserTypeinUserDefaults() {
+        userDefaults.removeObject(forKey: "UserType")
     }
 }


### PR DESCRIPTION
이슈
- #141 코드는 fireStore에 사용자 데이터 존재 여부를 체크하는 코드로 원하는 기능을 수행합니다.
- 하지만 로그인 상태 유지 측면에서 제대로 동작하지 않습니다.
<br/>
아직 위 이슈에 대한 원인을 찾지 못해서 일단 #141 이전 코드로 돌려놓겠습니다.
일단은 데이터 삭제해야 하는 상황일 때는 fireStore에서 데이터 삭제하지 마시고 앱 내에서 계정 삭제 해주세요.