### PR TITLE
Design/Fix: 채팅방 디자인 전면 수정 및 Utility Menu와 키보드 동시에 나오던 이슈 해결

### DIFF
--- a/YeDi/YeDi.xcodeproj/project.pbxproj
+++ b/YeDi/YeDi.xcodeproj/project.pbxproj
@@ -35,7 +35,6 @@
 		3B6346DE2AD9004600D3D110 /* ChatListUserInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B6346DD2AD9004600D3D110 /* ChatListUserInfo.swift */; };
 		3BA51B6B2AD53212009D7902 /* SingleTonDateFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BA51B6A2AD53212009D7902 /* SingleTonDateFormatter.swift */; };
 		3BA862E12ADF96D500385507 /* DMShopEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BA862E02ADF96D500385507 /* DMShopEditView.swift */; };
-		3BA862E32ADFD22400385507 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3BA862E22ADFD22400385507 /* GoogleService-Info.plist */; };
 		3BAB00EB2ACD92D6009053A4 /* DMAccount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BAB00EA2ACD92D5009053A4 /* DMAccount.swift */; };
 		3BAB00F12ACD948C009053A4 /* DMExpandableText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BAB00F02ACD948B009053A4 /* DMExpandableText.swift */; };
 		3BAB00F32ACD97EB009053A4 /* ReservationSDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BAB00F22ACD97EA009053A4 /* ReservationSDetail.swift */; };
@@ -165,7 +164,6 @@
 		3B6346DD2AD9004600D3D110 /* ChatListUserInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatListUserInfo.swift; sourceTree = "<group>"; };
 		3BA51B6A2AD53212009D7902 /* SingleTonDateFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleTonDateFormatter.swift; sourceTree = "<group>"; };
 		3BA862E02ADF96D500385507 /* DMShopEditView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DMShopEditView.swift; sourceTree = "<group>"; };
-		3BA862E22ADFD22400385507 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../../../../Downloads/GoogleService-Info.plist"; sourceTree = "<group>"; };
 		3BAB00EA2ACD92D5009053A4 /* DMAccount.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DMAccount.swift; sourceTree = "<group>"; };
 		3BAB00F02ACD948B009053A4 /* DMExpandableText.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DMExpandableText.swift; sourceTree = "<group>"; };
 		3BAB00F22ACD97EA009053A4 /* ReservationSDetail.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReservationSDetail.swift; sourceTree = "<group>"; };

--- a/YeDi/YeDi/Shared/View/Chatting/BubbleCell.swift
+++ b/YeDi/YeDi/Shared/View/Chatting/BubbleCell.swift
@@ -69,6 +69,6 @@ struct BubbleCell: View {
     private var readMarkCircle: some View {
         Circle()
             .frame(width: 8, height: 8)
-            .foregroundStyle(Color(red: 1, green: 0.19, blue: 0.53))
+            .foregroundStyle(Color.subColor)
     }
 }

--- a/YeDi/YeDi/Shared/View/Chatting/ChatUtilityMenuView.swift
+++ b/YeDi/YeDi/Shared/View/Chatting/ChatUtilityMenuView.swift
@@ -10,8 +10,10 @@ import PhotosUI
 
 struct ChatUtilityMenuView: View {
     @State private var selectedItem: PhotosPickerItem?
+    
     var chattingVM : ChattingViewModel
     var userID: String
+    
     var body: some View {
         HStack {
             Spacer()
@@ -22,9 +24,16 @@ struct ChatUtilityMenuView: View {
                         Image(systemName: "photo.circle.fill")
                             .resizable()
                             .scaledToFit()
-                            .frame(width: 50, height: 50)
-                        Text("사진")
+                            .frame(width: 25)
+                            .foregroundStyle(Color.white)
                     }
+                    .padding(13)
+                    .background {
+                        Circle()
+                            .fill(Color.pointColor)
+                    }
+                    Text("사진")
+                        .font(.caption)
                 }
             }
             .onChange(of: selectedItem) { newItem in ///사진앱에서 선택된 사진이 저장되고 Data로 형변환 되는 코드
@@ -39,20 +48,29 @@ struct ChatUtilityMenuView: View {
             Spacer()
             
             Button(action: {}, label: {
-                VStack{
-                    Image(systemName: "clock.badge.checkmark.fill")
-                        .resizable()
-                        .scaledToFit()
-                        .frame(width: 50, height: 50)
+                VStack {
+                    VStack{
+                        Image(systemName: "clock.fill")
+                            .resizable()
+                            .scaledToFit()
+                            .frame(width: 25)
+                            .foregroundStyle(Color.white)
+                    }
+                    .padding(13)
+                    .background {
+                        Circle()
+                            .fill(Color.indigo)
+                    }
                     Text("바로예약")
+                        .font(.caption)
                 }
             })
             
             Spacer()
         }
-        .padding()
-        .background(.gray.opacity(0.4))
-        //MARK: 색상 변경시 여기 수정
+        .padding(.top)
+        .padding(.bottom, 30)
+        .background(Color.tertiarySystemBackground)
         .foregroundStyle(.primary)
         .frame(minWidth: 0, maxWidth: .infinity)
     }

--- a/YeDi/YeDi/Shared/ViewModifier/ChatBubbleModifier.swift
+++ b/YeDi/YeDi/Shared/ViewModifier/ChatBubbleModifier.swift
@@ -14,10 +14,10 @@ struct ChatBubbleModifier: ViewModifier {
         content
             .padding(.horizontal)
             .padding(.vertical, 11)
-            .foregroundColor(isMyChat ? .white : .black)
+            .foregroundColor(isMyChat ? .white : .primaryLabel)
             .background {
                 RoundedRectangle(cornerRadius: 15)
-                    .fill(isMyChat ? .black : Color(red: 0.85, green: 0.85, blue: 0.85))
+                    .fill(isMyChat ? .mainColor : Color.gray5)
             }
     }
 }


### PR DESCRIPTION
- 다크모드 대응 컬러 수정
- 지난 대화 보기 버튼 디자인 수정
- 마지막 채팅 버블 `.padding(.bottom)` 추가하여 메시지 입력창과의 간격 조정
- 화면 스크롤 시 키보드 사라지도록 수정
- Utility Menu 디자인 수정
- `@FocusState`를 통해 메시지 입력창이 Focus가 되면 Utility Menu는 사라지도록 변경
<img src="https://github.com/APPSCHOOL3-iOS/final-yedi/assets/68881093/ce2ca313-9234-4918-88f0-b16f172baa1a" width="300" />
<img src="https://github.com/APPSCHOOL3-iOS/final-yedi/assets/68881093/4ecdaf60-6658-4859-a938-b5c1dc3fc951" width="300" />
<img src="https://github.com/APPSCHOOL3-iOS/final-yedi/assets/68881093/38fd403a-acd2-4a75-8c36-aec537269064" width="300" />
<img src="https://github.com/APPSCHOOL3-iOS/final-yedi/assets/68881093/d4ded35c-0214-4211-b551-a5fddf337f6c" width="300" />
