### PR TITLE
Fix: 디자이너 컬랙션이  샵 컬랙션 을 포함하는 구조로 변경

### DIFF
--- a/YeDi/YeDi.xcodeproj/project.pbxproj
+++ b/YeDi/YeDi.xcodeproj/project.pbxproj
@@ -23,12 +23,12 @@
 		2F0A21912ACE753F0070CA42 /* CMProfileViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0A21902ACE753F0070CA42 /* CMProfileViewModel.swift */; };
 		2F0A21932ACFD4B00070CA42 /* Review.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0A21922ACFD4B00070CA42 /* Review.swift */; };
 		2F0A21952ACFD8950070CA42 /* CMReviewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0A21942ACFD8950070CA42 /* CMReviewViewModel.swift */; };
-		2F0B733B2AE0E9B100868EF6 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 2F0B733A2AE0E9B100868EF6 /* GoogleService-Info.plist */; };
 		2F45A1282AD2739C005018A5 /* Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F45A1272AD2739C005018A5 /* Color.swift */; };
 		2F6363E92AD542AA00E980F8 /* PhotoPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F6363E82AD542AA00E980F8 /* PhotoPicker.swift */; };
 		2F7B60652ADFAF2B00EF1B96 /* CMCustomTextArea.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F7B60642ADFAF2B00EF1B96 /* CMCustomTextArea.swift */; };
 		2FA36FFE2AD93C1F00E750B0 /* CMReservationInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA36FFD2AD93C1F00E750B0 /* CMReservationInfoView.swift */; };
 		2FA370002AD945A000E750B0 /* PhotoSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA36FFF2AD945A000E750B0 /* PhotoSelectionView.swift */; };
+		3B0E1CD42AE204CC00145563 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B0E1CD32AE204CC00145563 /* GoogleService-Info.plist */; };
 		3B2442F52ADE5CF7005D3021 /* StarScoreView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B2442F42ADE5CF7005D3021 /* StarScoreView.swift */; };
 		3B517D482ACE46420082E2F6 /* ConsultationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B517D472ACE46420082E2F6 /* ConsultationViewModel.swift */; };
 		3B6346DC2AD8DDD300D3D110 /* NSCacheManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B6346DB2AD8DDD300D3D110 /* NSCacheManager.swift */; };
@@ -152,12 +152,12 @@
 		2F0A21902ACE753F0070CA42 /* CMProfileViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMProfileViewModel.swift; sourceTree = "<group>"; };
 		2F0A21922ACFD4B00070CA42 /* Review.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Review.swift; sourceTree = "<group>"; };
 		2F0A21942ACFD8950070CA42 /* CMReviewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMReviewViewModel.swift; sourceTree = "<group>"; };
-		2F0B733A2AE0E9B100868EF6 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		2F45A1272AD2739C005018A5 /* Color.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Color.swift; sourceTree = "<group>"; };
 		2F6363E82AD542AA00E980F8 /* PhotoPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoPicker.swift; sourceTree = "<group>"; };
 		2F7B60642ADFAF2B00EF1B96 /* CMCustomTextArea.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMCustomTextArea.swift; sourceTree = "<group>"; };
 		2FA36FFD2AD93C1F00E750B0 /* CMReservationInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMReservationInfoView.swift; sourceTree = "<group>"; };
 		2FA36FFF2AD945A000E750B0 /* PhotoSelectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoSelectionView.swift; sourceTree = "<group>"; };
+		3B0E1CD32AE204CC00145563 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../../../../Downloads/GoogleService-Info.plist"; sourceTree = "<group>"; };
 		3B2442F42ADE5CF7005D3021 /* StarScoreView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StarScoreView.swift; sourceTree = "<group>"; };
 		3B517D472ACE46420082E2F6 /* ConsultationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsultationViewModel.swift; sourceTree = "<group>"; };
 		3B6346DB2AD8DDD300D3D110 /* NSCacheManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSCacheManager.swift; sourceTree = "<group>"; };
@@ -618,7 +618,6 @@
 		63CD89A42ABD85C300E70A56 = {
 			isa = PBXGroup;
 			children = (
-				2F0B733A2AE0E9B100868EF6 /* GoogleService-Info.plist */,
 				63CD89AF2ABD85C300E70A56 /* YeDi */,
 				63CD89AE2ABD85C300E70A56 /* Products */,
 				9691C5CE2ADE549600434377 /* Frameworks */,
@@ -636,6 +635,7 @@
 		63CD89AF2ABD85C300E70A56 /* YeDi */ = {
 			isa = PBXGroup;
 			children = (
+				3B0E1CD32AE204CC00145563 /* GoogleService-Info.plist */,
 				3BCF2C032ACD3E72009C18C2 /* Shared */,
 				3BCF2C362ACD4247009C18C2 /* Client */,
 				639DB6282AC10DED002692E5 /* Designer */,
@@ -794,7 +794,7 @@
 			files = (
 				63CD89B82ABD85C500E70A56 /* Preview Assets.xcassets in Resources */,
 				63CD89B52ABD85C500E70A56 /* Assets.xcassets in Resources */,
-				2F0B733B2AE0E9B100868EF6 /* GoogleService-Info.plist in Resources */,
+				3B0E1CD42AE204CC00145563 /* GoogleService-Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/YeDi/YeDi/Designer/Model/DmDesignerModels.swift
+++ b/YeDi/YeDi/Designer/Model/DmDesignerModels.swift
@@ -10,7 +10,7 @@ import Foundation
 
 // 샵에 대한 정보를 담는 구조체
 struct Shop: Codable {
-    var id: String = UUID().uuidString
+    @DocumentID var id: String?
     
     var shopName: String  // 샵 이름
     /// [시] 만 담고 있는 주소
@@ -22,7 +22,7 @@ struct Shop: Codable {
     /// 샵 전화번호
     var telNumber: String?
     /// 위도
-    var longitude: Double?  // 오타 수정: langitude -> longitude
+    var longitude: Double?
     /// 경도
     var latitude: Double?
     /// 시작시간
@@ -67,6 +67,8 @@ struct Designer: Codable {
     var rank: Rank
     /// 디자이너 고유 ID
     var designerUID: String
+    /// 디자이너 샵 정보
+    var shop: Shop?
 }
 
 /// 직급

--- a/YeDi/YeDi/Designer/View/DMProfileView/DMShopEditView.swift
+++ b/YeDi/YeDi/Designer/View/DMProfileView/DMShopEditView.swift
@@ -22,7 +22,7 @@ struct DMShopEditView: View {
     @State private var closingHour: Date = Date()
     
     @Environment(\.colorScheme) var colorScheme
-    
+    @EnvironmentObject var userAuth: UserAuth
     private let ranks: [Rank] = [.Owner, .Principal, .Designer, .Intern]
     
     var body: some View {
@@ -77,14 +77,20 @@ struct DMShopEditView: View {
                         
                         VStack(alignment: .leading, spacing: 5) {
                             Text("시/군/구")
-                            TextField("주소", text: $shop.headAddress)
-                                .signInTextFieldStyle(isTextFieldValid: $isNotEmptyDescription)
+                            TextField("시/군/구", text: $shop.headAddress)
+                                .textFieldModifier()
                         }
                         
                         VStack(alignment: .leading, spacing: 5) {
                             Text("도로명")
-                            TextField("주소 ", text: $shop.subAddress)
-                                .signInTextFieldStyle(isTextFieldValid: $isNotEmptyDescription)
+                            TextField("도로명", text: $shop.subAddress)
+                                .textFieldModifier()
+                        }
+                        
+                        VStack(alignment: .leading, spacing: 5) {
+                            Text("상세주소")
+                            TextField("상세주소 ", text: $shop.detailAddress)
+                                .textFieldModifier()
                         }
                     }
                     .padding(.vertical, 8)

--- a/YeDi/YeDi/Shared/ViewModel/Auth/AuthViewModel.swift
+++ b/YeDi/YeDi/Shared/ViewModel/Auth/AuthViewModel.swift
@@ -205,26 +205,31 @@ final class UserAuth: ObservableObject {
                     "gender": designer.gender,
                     "rank": designer.rank.rawValue,
                     "designerUID": user.uid,
-                    //MARK: shop information
-                    "shopName" : shop.shopName,
-                    "headAddress" : shop.headAddress,
-                    "subAddress" : shop.subAddress,
-                    "detailAddress" : shop.detailAddress,
-                    // "telNumber" : "",
-                    // "longitude" : "",
-                    // "latitude" : "",
-                    "openingHour" : shop.openingHour,
-                    "closingHour" : shop.closingHour,
-                    // "messangerLinkURL" : ["": ""],
-                    "closedDays" : shop.closedDays
                 ]
                 
                 self.storeService.collection("designers")
                     .document(user.uid)
                     .setData(data, merge: true)
                 
-                self.userSession = nil
-                self.isLogin = false
+                let shopData : [String: Any] = [
+                                    "shopName" : shop.shopName,
+                                    "headAddress" : shop.headAddress,
+                                    "subAddress" : shop.subAddress,
+                                    "detailAddress" : shop.detailAddress,
+//                                    "telNumber" : "",
+//                                    "longitude" : "",
+//                                    "latitude" : "",
+                                    "openingHour" : shop.openingHour,
+                                    "closingHour" : shop.closingHour,
+//                                    "messangerLinkURL" : ["": ""],
+                                    "closedDays" : shop.closedDays
+                                ]
+                
+                self.storeService.collection("designers").document(user.uid).collection("shop")
+                                  .addDocument(data: shopData, completion: { _ in
+                                      self.userSession = nil
+                                      self.isLogin = false
+                                  })
             }
         }
     }


### PR DESCRIPTION
1. 아래와 같이 데이터 파싱 사용가능
```swift
func fetchuserInfo() {
    let designerDocRef = self.storeService.collection("designers").document("osjTYFAv8ignfCRv50cmUtT0SWl1")
    designerDocRef.getDocument { designerSnapshot, error in
        do {
            let designer = try designerSnapshot?.data(as: Designer.self)
            print(designer)

            // 이제 Designer에 대한 Shop 컬렉션을 가져옵니다.
            designerDocRef.collection("shop").getDocuments { shopSnapshot, error in
                shopSnapshot?.documents.forEach { document in
                    do {
                        let shop = try document.data(as: Shop.self)
                        print(shop)
                    } catch {
                        print("Error decoding shop: \(error)")
                    }
                }
            }
        } catch {
            print("Error decoding designer: \(error)")
        }
    }
}
```