### PR TITLE
Feat: 다크모드 대응 및 세부 디자인 일부 변경

### DIFF
--- a/YeDi/YeDi/Client/View/CMHome/CMFollowingPostView.swift
+++ b/YeDi/YeDi/Client/View/CMHome/CMFollowingPostView.swift
@@ -29,13 +29,6 @@ struct CMFollowingPostView: View {
                     }
                 }
             }
-            .toolbar {
-                ToolbarItem(placement: .topBarLeading) {
-                    Text("YeDi")
-                        .font(.title)
-                        .fontWeight(.bold)
-                }
-            }
             .onAppear {
                 postViewModel.fetchPostsForFollowedDesigners(clientID: userAuth.currentClientID ?? "")
             }

--- a/YeDi/YeDi/Client/View/CMHome/CMHomeView.swift
+++ b/YeDi/YeDi/Client/View/CMHome/CMHomeView.swift
@@ -14,7 +14,7 @@ struct CMHomeView: View {
     
     var body: some View {
         NavigationStack {
-            HStack {
+            HStack(spacing: 0) {
                 ForEach(segments, id: \.self) { segment in
                     Button(action: {
                         selectedSegment = segment
@@ -22,15 +22,31 @@ struct CMHomeView: View {
                         VStack {
                             Text(segment)
                                 .fontWeight(selectedSegment == segment ? .semibold : .medium)
-                                .foregroundStyle(Color.primaryLabel)
+                                .foregroundStyle(Color(UIColor.label))
                             Rectangle()
-                                .fill(selectedSegment == segment ? Color.primaryLabel : .clear)
-                                .frame(width: 180, height: 3)
+                                .fill(selectedSegment == segment ? Color.primaryLabel : .gray6)
+                                .frame(width: 200, height: 3)
                         }
                     })
                 }
             }
             .padding(.top)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Text("YeDi")
+                        .font(.title)
+                        .fontWeight(.bold)
+                }
+                
+                ToolbarItem(placement: .topBarTrailing) {
+                    NavigationLink {
+                        CMSettingsView()
+                    } label: {
+                        Image(systemName: "gearshape")
+                            .foregroundStyle(Color.primaryLabel)
+                    }
+                }
+            }
             
             switch selectedSegment {
             case "회원님을 위한 추천":

--- a/YeDi/YeDi/Client/View/CMHome/CMRecommendPostView.swift
+++ b/YeDi/YeDi/Client/View/CMHome/CMRecommendPostView.swift
@@ -29,13 +29,6 @@ struct CMRecommendPostView: View {
                     }
                 })
             }
-            .toolbar {
-                ToolbarItem(placement: .topBarLeading) {
-                    Text("YeDi")
-                        .font(.title)
-                        .fontWeight(.bold)
-                }
-            }
             .task {
                 await postViewModel.fetchPosts()
             }

--- a/YeDi/YeDi/Client/View/CMProfile/CMFollowingListView.swift
+++ b/YeDi/YeDi/Client/View/CMProfile/CMFollowingListView.swift
@@ -42,26 +42,26 @@ struct CMFollowingListView: View {
     private func followingList(designer: Designer) -> some View {
         HStack(alignment: .top) {
             if let imageURLString = designer.imageURLString {
-                AsyncImage(url: URL(string: "\(imageURLString)")) { image in
-                    image
-                        .resizable()
-                        .aspectRatio(contentMode: .fill)
-                        .frame(maxWidth: 50, maxHeight: 50)
-                        .clipShape(Circle())
-                } placeholder: {
-                    ProgressView()
-                }
+                DMAsyncImage(url: imageURLString)
+                    .aspectRatio(contentMode: .fill)
+                    .frame(maxWidth: 50, maxHeight: 50)
+                    .clipShape(Circle())
+                    .offset(y: -5)
+                    .padding(.trailing, 4)
             } else {
                 Image(systemName: "person.circle.fill")
                     .resizable()
                     .aspectRatio(contentMode: .fit)
                     .frame(maxWidth: 50, maxHeight: 50)
                     .clipShape(Circle())
+                    .offset(y: -5)
+                    .padding(.trailing, 4)
             }
 
             VStack(alignment: .leading) {
                 Text("\(designer.name)")
                 Text("서울")
+                    .font(.subheadline)
             }
             
             Spacer()

--- a/YeDi/YeDi/Client/View/CMProfile/CMProfileEdit/CMClientInfoEditView.swift
+++ b/YeDi/YeDi/Client/View/CMProfile/CMProfileEdit/CMClientInfoEditView.swift
@@ -47,12 +47,13 @@ struct CMClientInfoEditView: View {
                                 .foregroundStyle(Color.primaryLabel)
                                 .background(
                                     RoundedRectangle(cornerRadius: 2)
-                                        .stroke(Color.systemFill, lineWidth: 1)
+                                        .stroke(Color.gray6, lineWidth: 2)
                                 )
                         })
-                        .background(selectedGender == gender ? Color.systemFill : .myColor)
+                        .background(selectedGender == gender ? Color.gray4 : Color.gray6)
                     }
                 }
+                
                 Spacer()
             }
             .padding(.bottom, 15)

--- a/YeDi/YeDi/Client/View/CMProfile/CMProfileView.swift
+++ b/YeDi/YeDi/Client/View/CMProfile/CMProfileView.swift
@@ -80,16 +80,6 @@ struct CMProfileView: View {
                 clientPhoneNumber = profileViewModel.client.phoneNumber
             }
         }
-        .toolbar {
-            ToolbarItem(placement: .topBarTrailing) {
-                NavigationLink {
-                    CMSettingsView()
-                } label: {
-                    Image(systemName: "gearshape")
-                        .foregroundStyle(Color.primaryLabel)
-                }
-            }
-        }
     }
 }
 

--- a/YeDi/YeDi/Client/View/CMProfile/CMReviewListView.swift
+++ b/YeDi/YeDi/Client/View/CMProfile/CMReviewListView.swift
@@ -79,11 +79,11 @@ struct CMReviewCell: View {
                 ForEach(review.keywordReviews) { keywordReview in
                     Text("\(keywordReview.keyword)")
                         .font(.subheadline)
-                        .foregroundStyle(.black)
+                        .foregroundStyle(Color.primaryLabel)
                         .padding(10)
                         .background(
                             RoundedRectangle(cornerRadius: 5)
-                                .stroke(Color(white: 0.9), lineWidth: 1)
+                                .stroke(Color.systemFill, lineWidth: 1)
                         )
                 }
             }


### PR DESCRIPTION
- modified:   YeDi/YeDi/Client/View/CMHome/CMFollowingPostView.swift
  - 기존 툴바 제거
- modified:   YeDi/YeDi/Client/View/CMHome/CMHomeView.swift
  - 앱 전체 툴바 통일 (어떤 탭을 누르든 동일한 툴바가 나오도록), 세그먼티드 컨트롤 디자인 변경
- modified:   YeDi/YeDi/Client/View/CMHome/CMRecommendPostView.swift
  - 기존 툴바 제거
- modified:   YeDi/YeDi/Client/View/CMProfile/CMFollowingListView.swift
  - 프로필 이미지 AsyncImage > DMAsyncImage로 변경
- modified:   YeDi/YeDi/Client/View/CMProfile/CMProfileEdit/CMClientInfoEditView.swift
  - 성별 고르는 피커 > 다크모드 대응
- modified:   YeDi/YeDi/Client/View/CMProfile/CMProfileView.swift
  - 기존 설정 툴바 제거 (홈 뷰로 이동)
- modified:   YeDi/YeDi/Client/View/CMProfile/CMReviewListView.swift
  - 키워드 리뷰 텍스트 > 다크모드 대응