### PR TITLE
Feat/Fix: 패스워드 SecureField 추가 및 onChange 변경값 실수 해결

### DIFF
--- a/YeDi/YeDi/Shared/View/Auth/LoginView.swift
+++ b/YeDi/YeDi/Shared/View/Auth/LoginView.swift
@@ -19,6 +19,7 @@ struct LoginView: View {
     
     @State private var isEmailValid: Bool = true
     @State private var isPasswordValid: Bool = true
+    @State private var isShowingPassword: Bool = false
     
     var body: some View {
         VStack(spacing: 20) {
@@ -77,12 +78,26 @@ struct LoginView: View {
     private var inputPasswordTextField: some View {
         VStack(alignment: .leading, spacing: 5) {
             Text("패스워드")
-            TextField("패스워드", text: $password)
-                .keyboardType(.emailAddress)
-                .signInTextFieldStyle(isTextFieldValid: $isPasswordValid)
-                .onChange(of: email) { newValue in
-                    email = newValue.trimmingCharacters(in: .whitespaces)
+            
+            HStack {
+                if isShowingPassword {
+                    TextField("패스워드", text: $password)
+                } else {
+                    SecureField("패스워드", text: $password)
                 }
+                
+                Spacer()
+                
+                Button(action: {
+                    isShowingPassword.toggle()
+                }, label: {
+                    Image(systemName: isShowingPassword ? "eye.fill" : "eye.slash.fill")
+                })
+            }
+            .signInTextFieldStyle(isTextFieldValid: $isPasswordValid)
+            .onChange(of: password) { newValue in
+                password = newValue.trimmingCharacters(in: .whitespaces)
+            }
         }
     }
     

--- a/YeDi/YeDi/Shared/View/Auth/RegisterView.swift
+++ b/YeDi/YeDi/Shared/View/Auth/RegisterView.swift
@@ -53,6 +53,9 @@ struct RegisterView: View {
     @State private var birthDate: String = ""
     @State private var isShowingDatePicker: Bool = false
     
+    @State private var isShowingPassword: Bool = false
+    @State private var isShowingDoubleCheckPassword: Bool = false
+    
     private let genders: [String] = ["여성", "남성"]
     private let ranks: [Rank] = [.Owner, .Principal, .Designer, .Intern]
     
@@ -134,13 +137,26 @@ struct RegisterView: View {
             
             VStack(alignment: .leading, spacing: 5) {
                 Text("패스워드 *")
-                TextField("패스워드", text: $password)
-                    .signInTextFieldStyle(isTextFieldValid: $isPasswordValid)
-                    .onChange(of: password) { newValue in
-                        if !checkPassword() {
-                            password = newValue.trimmingCharacters(in: .whitespaces)
-                        }
+                
+                HStack {
+                    if isShowingPassword {
+                        TextField("패스워드", text: $password)
+                    } else {
+                        SecureField("패스워드", text: $password)
                     }
+                    
+                    Spacer()
+                    
+                    Button(action: {
+                        isShowingPassword.toggle()
+                    }, label: {
+                        Image(systemName: isShowingPassword ? "eye.fill" : "eye.slash.fill")
+                    })
+                }
+                .signInTextFieldStyle(isTextFieldValid: $isPasswordValid)
+                .onChange(of: password) { newValue in
+                    password = newValue.trimmingCharacters(in: .whitespaces)
+                }
                 
                 Text(cautionPassword)
                     .cautionTextStyle()
@@ -148,13 +164,28 @@ struct RegisterView: View {
             
             VStack(alignment: .leading, spacing: 5) {
                 Text("패스워드 체크 *")
-                TextField("패스워드 체크", text: $doubleCheckPassword)
-                    .signInTextFieldStyle(isTextFieldValid: $isDoubleCheckPasswordValid)
-                    .onChange(of: doubleCheckPassword) { newValue in
-                        if !doubleCheckPasswordValid() {
-                            doubleCheckPassword = newValue.trimmingCharacters(in: .whitespaces)
-                        }
+                
+                HStack {
+                    if isShowingDoubleCheckPassword {
+                        TextField("패스워드", text: $doubleCheckPassword)
+                    } else {
+                        SecureField("패스워드", text: $doubleCheckPassword)
                     }
+                    
+                    Spacer()
+                    
+                    Button(action: {
+                        isShowingDoubleCheckPassword.toggle()
+                    }, label: {
+                        Image(systemName: isShowingDoubleCheckPassword ? "eye.fill" : "eye.slash.fill")
+                    })
+                }
+                .signInTextFieldStyle(isTextFieldValid: $isDoubleCheckPasswordValid)
+                .onChange(of: doubleCheckPassword) { newValue in
+                    if !doubleCheckPasswordValid() {
+                        doubleCheckPassword = newValue.trimmingCharacters(in: .whitespaces)
+                    }
+                }
                 
                 Text(cautionDoubleCheckPassword)
                     .cautionTextStyle()


### PR DESCRIPTION
- 로그인, 회원가입 패스워드 `TextField`와 `SecureField` 추가
- 패스워드 관련 `onChange` 변경 값이 email로 되어 있던 코드 password에 맞게 변경
```
.onChange(of: password) { newValue in
    password = newValue.trimmingCharacters(in: .whitespaces)
}
```
<img src="https://github.com/APPSCHOOL3-iOS/final-yedi/assets/68881093/0e30d97a-024e-4ab8-939f-d3cc77f84698" width="300" />
<img src="https://github.com/APPSCHOOL3-iOS/final-yedi/assets/68881093/bcba37df-72d9-42ea-8adf-0f748cdeeae3" width="300" />
