### PR TITLE
Fix, Design: designer profile image change, edit search route

### DIFF
--- a/YeDi/YeDi/Client/View/CMHome/CMDesignerProfile/CMDesignerProfileView.swift
+++ b/YeDi/YeDi/Client/View/CMHome/CMDesignerProfile/CMDesignerProfileView.swift
@@ -30,7 +30,7 @@ struct CMDesignerProfileView: View {
                                             .font(.title)
                                             .fontWeight(.bold)
                                             .frame(width: 80, height: 80)
-                                            .background(Circle().fill(.gray))
+                                            .background(Circle().fill(Color.quaternarySystemFill))
                                             .foregroundColor(Color.primaryLabel)
                             }
                         } else {
@@ -38,7 +38,7 @@ struct CMDesignerProfileView: View {
                                         .font(.title)
                                         .fontWeight(.bold)
                                         .frame(width: 80, height: 80)
-                                        .background(Circle().fill(.gray))
+                                        .background(Circle().fill(Color.quaternarySystemFill))
                                         .foregroundColor(Color.primaryLabel)
                             
                         }

--- a/YeDi/YeDi/Client/View/CMHome/CMHomeCellView.swift
+++ b/YeDi/YeDi/Client/View/CMHome/CMHomeCellView.swift
@@ -86,7 +86,7 @@ private struct CMHomeCellHeaderView: View {
                                         .font(.title3)
                                         .fontWeight(.bold)
                                         .frame(width: 50, height: 50)
-                                        .background(Circle().fill(.gray))
+                                        .background(Circle().fill(Color.quaternarySystemFill))
                                         .foregroundColor(Color.primaryLabel)
                         }
                     } else {
@@ -94,7 +94,7 @@ private struct CMHomeCellHeaderView: View {
                                     .font(.title3)
                                     .fontWeight(.bold)
                                     .frame(width: 50, height: 50)
-                                    .background(Circle().fill(.gray))
+                                    .background(Circle().fill(Color.quaternarySystemFill))
                                     .foregroundColor(Color.primaryLabel)
 
                     }

--- a/YeDi/YeDi/Client/View/CMHome/CMSearch/CMSearchView.swift
+++ b/YeDi/YeDi/Client/View/CMHome/CMSearch/CMSearchView.swift
@@ -16,13 +16,15 @@ struct CMSearchView: View {
         NavigationStack {
             HStack {
                 ZStack(alignment: .trailing) {
-                    TextField("디자이너를 검색해보세요.", text: $viewModel.searchText, onCommit: {
-                        viewModel.saveRecentSearch()
-                    })
+                    TextField("디자이너를 검색해보세요.", text: $viewModel.searchText)
                     .textFieldModifier()
+                    .onSubmit {
+                        viewModel.saveRecentSearch()
+                    }
+                    
                     if !viewModel.searchText.isEmpty {
                         Button(action: {
-                            viewModel.saveRecentSearch()
+                            viewModel.searchText = ""
                         }) {
                             Image(systemName: "xmark.circle.fill")
                                 .foregroundColor(.gray)
@@ -45,7 +47,7 @@ struct CMSearchView: View {
                                 viewModel.removeAllRecentSearches()
                             }) {
                                 Text("전체 삭제")
-                                    .foregroundColor(Color.subColor)
+                                    .foregroundColor(Color.primaryLabel)
                             }
                         }
                     }
@@ -56,7 +58,6 @@ struct CMSearchView: View {
                         HStack {
                             Button {
                                 viewModel.searchText = search
-                                //viewModel.performSearch()
                             } label: {
                                 HStack {
                                     Image(systemName: "magnifyingglass")
@@ -94,53 +95,55 @@ struct CMSearchView: View {
                     }
                     .padding(.horizontal)
                     Divider()
-                    ForEach(viewModel.filterDesigners, id: \.id) { designer in
-                        NavigationLink(destination: CMDesignerProfileView(designer: designer)) {
-                            VStack {
-                                HStack {
-                                    if let imageURLString = designer.imageURLString {
-                                        AsyncImage(url: URL(string: "\(imageURLString)")) { image in
-                                            image
-                                                .resizable()
-                                                .aspectRatio(contentMode: .fill)
-                                                .frame(maxWidth: 50, maxHeight: 50)
-                                                .clipShape(Circle())
-                                        } placeholder: {
+                    ScrollView {
+                        ForEach(viewModel.filterDesigners, id: \.id) { designer in
+                            NavigationLink(destination: CMDesignerProfileView(designer: designer)) {
+                                VStack {
+                                    HStack {
+                                        if let imageURLString = designer.imageURLString {
+                                            AsyncImage(url: URL(string: "\(imageURLString)")) { image in
+                                                image
+                                                    .resizable()
+                                                    .aspectRatio(contentMode: .fill)
+                                                    .frame(maxWidth: 50, maxHeight: 50)
+                                                    .clipShape(Circle())
+                                            } placeholder: {
+                                                Text(String(designer.name.first ?? " ").capitalized)
+                                                            .font(.title3)
+                                                            .fontWeight(.bold)
+                                                            .frame(width: 50, height: 50)
+                                                            .background(Circle().fill(Color.quaternarySystemFill))
+                                                            .foregroundColor(Color.primaryLabel)
+                                            }
+                                        } else {
                                             Text(String(designer.name.first ?? " ").capitalized)
                                                         .font(.title3)
                                                         .fontWeight(.bold)
                                                         .frame(width: 50, height: 50)
-                                                        .background(Circle().fill(.gray))
+                                                        .background(Circle().fill(Color.quaternarySystemFill))
                                                         .foregroundColor(Color.primaryLabel)
+                                            
                                         }
-                                    } else {
-                                        Text(String(designer.name.first ?? " ").capitalized)
-                                                    .font(.title3)
-                                                    .fontWeight(.bold)
-                                                    .frame(width: 50, height: 50)
-                                                    .background(Circle().fill(.gray))
-                                                    .foregroundColor(Color.primaryLabel)
-                                        
-                                    }
-                                    VStack(alignment: .leading) {
-                                        Text(designer.name)
-                                            .foregroundStyle(Color.primaryLabel)
-                                        if let shop = designer.shop {
-                                            Text(shop.shopName)
-                                                .font(.subheadline)
-                                                .foregroundStyle(.gray)
+                                        VStack(alignment: .leading) {
+                                            Text(designer.name)
+                                                .foregroundStyle(Color.primaryLabel)
+                                            if let shop = designer.shop {
+                                                Text(shop.shopName)
+                                                    .font(.subheadline)
+                                                    .foregroundStyle(.gray)
+                                            }
+                                            
+                                            
                                         }
-                                        
-                                        
+                                        .padding(.leading,5)
+                                        Spacer()
                                     }
-                                    .padding(.leading,5)
-                                    Spacer()
                                 }
                             }
                         }
+                        .padding()
+                        .listStyle(.plain)
                     }
-                    .padding()
-                    .listStyle(.plain)
                 } else {
                     Text("검색 결과가 없습니다.")
                         .foregroundStyle(Color.primaryLabel)
@@ -148,6 +151,9 @@ struct CMSearchView: View {
             }
             
             Spacer()
+        }
+        .onTapGesture {
+            hideKeyboard()
         }
         .onAppear {
             viewModel.loadData()

--- a/YeDi/YeDi/Client/ViewModel/CMSearchViewModel.swift
+++ b/YeDi/YeDi/Client/ViewModel/CMSearchViewModel.swift
@@ -39,7 +39,6 @@ class CMSearchViewModel: ObservableObject {
                 
                 UserDefaults.standard.set(recentSearches, forKey: "RecentSearches")
             }
-            searchText = ""
         }
     }
     
@@ -112,28 +111,4 @@ class CMSearchViewModel: ObservableObject {
             }
         }
     }
-
-
-    
-    func performSearch() {
-        designers = []
-
-        let query = db.collection("designers").whereField("name", isGreaterThanOrEqualTo: searchText)
-        
-        query.getDocuments { [weak self] snapshot, error in
-            if let error = error {
-                print("Error getting documents: \(error)")
-                return
-            }
-            guard let documents = snapshot?.documents else {
-                print("No documents")
-                return
-            }
-            self?.designers = documents.compactMap { document in
-                try? document.data(as: Designer.self)
-            }
-        }
-    }
-
-
 }


### PR DESCRIPTION
클라이언트가 보는 디자이너 프로필 이미지 수정

기존 검색 루트 : 텍스트 입력 > 엑스버튼 클릭 > 최근 검색어로 저장 & 텍스트 초기화
수정된 검색 루트 : 
텍스트 입력 > 키보드 내 retrun 클릭 > 최근 검색어로 저장
텍스트 입력 > 엑스버튼 클릭 > 텍스트 초기화 (검색을 하지 않았기에 최근 검색어로 저장 x)
