### PR TITLE
Fix: 디자이너 회원가입 샵정보 오픈/마감 시간 초기 선택 이슈 해결

### DIFF
--- a/YeDi/YeDi/Designer/View/DMProfileView/DMShopEditView.swift
+++ b/YeDi/YeDi/Designer/View/DMProfileView/DMShopEditView.swift
@@ -195,8 +195,8 @@ struct DMShopEditView: View {
                     let firebaseDateFormat = dateFomatter.firebaseDateFormat()
                     
                     closedDay = shop.closedDays.first ?? ""
-                    openingHour = firebaseDateFormat.date(from: shop.openingHour) ?? Date()
-                    closingHour = firebaseDateFormat.date(from: shop.closingHour) ?? Date()
+                    openingHour = firebaseDateFormat.date(from: "2000-01-01T10:00:00+0900") ?? Date()
+                    closingHour = firebaseDateFormat.date(from: "2000-01-01T19:00:00+0900") ?? Date()
                 })
                 .onTapGesture(perform: {
                     hideKeyboard()


### PR DESCRIPTION
- 오픈/마감 시간 선택 버튼 클릭시 초기값으로 설정되지 않고 현재 시간으로 나오던 이슈 해결했습니다.
<img src="https://github.com/APPSCHOOL3-iOS/final-yedi/assets/68881093/c63265c5-ccb3-4abb-bb15-390494f4b805" width="300" />
