### PR TITLE
Design: 

### DIFF
--- a/YeDi/YeDi.xcodeproj/project.pbxproj
+++ b/YeDi/YeDi.xcodeproj/project.pbxproj
@@ -563,12 +563,12 @@
 		639DB6622AC10F19002692E5 /* View */ = {
 			isa = PBXGroup;
 			children = (
+				639DB6602AC10F13002692E5 /* DesignerMainTabView.swift */,
 				639DB67C2AC11AE7002692E5 /* DMProfileView */,
 				639DB67F2AC11B17002692E5 /* DMChattingView */,
 				639DB6822AC11B29002692E5 /* DMReservationView */,
 				639DB6852AC11B4A002692E5 /* DMPostView */,
 				639DB67B2AC11AD5002692E5 /* DMReview */,
-				639DB6602AC10F13002692E5 /* DesignerMainTabView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";

--- a/YeDi/YeDi/Client/View/CMHome/CMHomeView.swift
+++ b/YeDi/YeDi/Client/View/CMHome/CMHomeView.swift
@@ -31,22 +31,6 @@ struct CMHomeView: View {
                 }
             }
             .padding(.top)
-            .toolbar {
-                ToolbarItem(placement: .topBarLeading) {
-                    Text("YeDi")
-                        .font(.title)
-                        .fontWeight(.bold)
-                }
-                
-                ToolbarItem(placement: .topBarTrailing) {
-                    NavigationLink {
-                        CMSettingsView()
-                    } label: {
-                        Image(systemName: "gearshape")
-                            .foregroundStyle(Color.primaryLabel)
-                    }
-                }
-            }
             
             switch selectedSegment {
             case "회원님을 위한 추천":

--- a/YeDi/YeDi/Client/View/CMProfile/CMFollowingListView.swift
+++ b/YeDi/YeDi/Client/View/CMProfile/CMFollowingListView.swift
@@ -42,25 +42,35 @@ struct CMFollowingListView: View {
     private func followingList(designer: Designer) -> some View {
         HStack(alignment: .top) {
             if let imageURLString = designer.imageURLString {
-                DMAsyncImage(url: imageURLString)
-                    .aspectRatio(contentMode: .fill)
-                    .frame(maxWidth: 50, maxHeight: 50)
-                    .clipShape(Circle())
-                    .offset(y: -5)
-                    .padding(.trailing, 4)
+                AsyncImage(url: URL(string: "\(imageURLString)")) { image in
+                    image
+                        .resizable()
+                        .aspectRatio(contentMode: .fill)
+                        .frame(maxWidth: 50, maxHeight: 50)
+                        .clipShape(Circle())
+                        .offset(y: -5)
+                } placeholder: {
+                    Text(String(designer.name.first ?? " ").capitalized)
+                                .font(.title3)
+                                .fontWeight(.bold)
+                                .frame(width: 50, height: 50)
+                                .background(Circle().fill(Color.quaternarySystemFill))
+                                .foregroundColor(Color.primaryLabel)
+                                .offset(y: -5)
+                }
             } else {
-                Image(systemName: "person.circle.fill")
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .frame(maxWidth: 50, maxHeight: 50)
-                    .clipShape(Circle())
-                    .offset(y: -5)
-                    .padding(.trailing, 4)
+                Text(String(designer.name.first ?? " ").capitalized)
+                            .font(.title3)
+                            .fontWeight(.bold)
+                            .frame(width: 50, height: 50)
+                            .background(Circle().fill(Color.quaternarySystemFill))
+                            .foregroundColor(Color.primaryLabel)
+                            .offset(y: -5)
             }
 
             VStack(alignment: .leading) {
                 Text("\(designer.name)")
-                Text("서울")
+                Text("\(designer.shop?.shopName ?? "프리랜서")")
                     .font(.subheadline)
             }
             

--- a/YeDi/YeDi/Client/View/CMProfile/CMProfileView.swift
+++ b/YeDi/YeDi/Client/View/CMProfile/CMProfileView.swift
@@ -35,8 +35,13 @@ struct CMProfileView: View {
                     
                     // MARK: - 프로필 이미지
                     if clientPhotoURL.isEmpty {
-                        Image(systemName: "person.circle.fill")
-                            .font(.system(size: 60))
+                        Text(String(profileViewModel.client.name.first ?? " ").capitalized)
+                            .font(.title3)
+                            .fontWeight(.bold)
+                            .frame(width: 60, height: 60)
+                            .background(Circle().fill(Color.quaternarySystemFill))
+                            .foregroundColor(Color.primaryLabel)
+                            .offset(y: -5)
                     } else {
                         DMAsyncImage(url: clientPhotoURL)
                             .aspectRatio(contentMode: .fill)

--- a/YeDi/YeDi/Client/View/CMProfile/CMReviewListView.swift
+++ b/YeDi/YeDi/Client/View/CMProfile/CMReviewListView.swift
@@ -53,17 +53,22 @@ struct CMReviewCell: View {
                         Spacer()
                         RatingView(score: review.designerScore, maxScore: 5, filledColor: .yellow)
                     }
+                    .padding(.bottom, 3)
+                    
                     Text(review.content)
+                        .font(.system(size: 15))
                         .foregroundStyle(Color.primaryLabel)
                         .lineLimit(2)
                         .multilineTextAlignment(.leading)
                     Spacer()
+                    
                     Text("\(SingleTonDateFormatter.sharedDateFommatter.changeDateString(transition: "yyyy년 MM월 dd일", from: review.date))")
                         .font(.footnote)
                         .foregroundStyle(.gray)
                 }
                 .padding(.vertical)
                 .padding(.leading)
+                
                 ZStack(alignment: .topTrailing) {
                     DMAsyncImage(url: review.imageURLStrings[0])
                         .scaledToFill()

--- a/YeDi/YeDi/Client/View/ClientMainTabView.swift
+++ b/YeDi/YeDi/Client/View/ClientMainTabView.swift
@@ -29,7 +29,7 @@ struct ClientMainTabView: View {
                 
                 CMReservationHistoryView()
                 .tabItem {
-                    Label("예약", systemImage: "chart.bar.doc.horizontal.fill")
+                    Label("예약", systemImage: "calendar")
                 }.tag(2)
                 
                 CMMainChattingView()

--- a/YeDi/YeDi/Shared/View/Chatting/ChattingListRoomView.swift
+++ b/YeDi/YeDi/Shared/View/Chatting/ChattingListRoomView.swift
@@ -36,9 +36,9 @@ struct ChattingListRoomView: View {
                                 .clipShape(Circle())
                                 .frame(width: 50, height: 50)
                                 
-                            VStack(alignment: .leading, spacing: 8) {
+                            VStack(alignment: .leading, spacing: 5) {
                                 Text(chattingListRoomViewModel.userProfile[chattingRoom.id]?.name ?? "UnKown")
-                                    .font(.title3.bold())
+                                    .font(.system(size: 17, weight: .semibold))
                                 HStack {
                                     VStack(alignment: .leading) {
                                         if let recentMessage =  chattingRoom.chattingBubles?.first {
@@ -77,11 +77,6 @@ struct ChattingListRoomView: View {
                 .animation(.easeInOut, value: chattingListRoomViewModel.chattingRooms)
                 .listStyle(.plain)
                 .navigationTitle("")
-                .toolbar {
-                    ToolbarItem(placement: .topBarLeading) {
-                        YdIconView(height: 30)
-                    }
-                }
             }
         }
         .onAppear {


### PR DESCRIPTION
- 네비게이션 바에 로고와 설정 아이콘이 여러개 나오는 현상 해결
<img src="https://github.com/APPSCHOOL3-iOS/final-yedi/assets/72439620/dbc5c97f-fd2b-48f9-bc16-7f3907d38a53" width=250 />

- 팔로잉 목록에서 디자이너 프로필 이미지가 없는 경우 이름의 앞글자가 나오도록 변경
- 기존에 서울로 하드코딩 되어있던 부분 > 샵 이름 or 샵 이름이 없는 경우에는 프리랜서로 뜨도록 변경
<img src="https://github.com/APPSCHOOL3-iOS/final-yedi/assets/72439620/a4376aed-744c-4af1-84e8-bf4c0cfde4f3" width=250 />

- 탭바 예약 아이콘 변경