### PR TITLE
Fix: 채팅방 바로예약 후 같은 메시지 중복으로 보이는 이슈 해결

### DIFF
--- a/YeDi/YeDi/Shared/View/Chatting/ChatRoomView.swift
+++ b/YeDi/YeDi/Shared/View/Chatting/ChatRoomView.swift
@@ -47,7 +47,7 @@ struct ChatRoomView: View {
             chatScroll
             inputchatTextField
             if isShowingUtilityMenu {
-                ChatUtilityMenuView(chattingVM: chattingVM, userID: userId, designerID: userProfile.uid)
+                ChatUtilityMenuView(userID: userId, designerID: userProfile.uid)
                     .transition(.move(edge: .bottom))
             }
         }
@@ -81,10 +81,20 @@ struct ChatRoomView: View {
                 chattingVM.removeListener()
             }
             HStack(alignment: .center) {
-                DMAsyncImage(url: userProfile.profileImageURLString)
-                    .aspectRatio(contentMode: .fill)
-                    .clipShape(Circle())
-                    .frame(width: 30, height: 30)
+                if userProfile.profileImageURLString.isEmpty {
+                    Text(String(userProfile.name.first ?? " ").capitalized)
+                        .font(.title3)
+                        .fontWeight(.bold)
+                        .frame(width: 50, height: 50)
+                        .background(Circle().fill(Color.quaternarySystemFill))
+                        .foregroundColor(Color.primaryLabel)
+                        .offset(y: -5)
+                } else {
+                    DMAsyncImage(url: userProfile.profileImageURLString)
+                        .aspectRatio(contentMode: .fill)
+                        .frame(width: 30, height: 30)
+                        .clipShape(Circle())
+                }
                 
                 Text(userProfile.name)
                     .lineLimit(1)
@@ -121,7 +131,7 @@ struct ChatRoomView: View {
                     .padding(.vertical)
                 }
                 
-                ForEach(chattingVM.chattings) { chat in
+                ForEach(Array(Set(chattingVM.chattings))) { chat in
                     var isMyBubble: Bool {
                         chat.sender == userId ? true : false
                     }

--- a/YeDi/YeDi/Shared/View/Chatting/ChatUtilityMenuView.swift
+++ b/YeDi/YeDi/Shared/View/Chatting/ChatUtilityMenuView.swift
@@ -9,10 +9,10 @@ import SwiftUI
 import PhotosUI
 
 struct ChatUtilityMenuView: View {
-    var chattingVM : ChattingViewModel
     var userID: String
     var designerID: String
     
+    @StateObject var chattingVM = ChattingViewModel()
     @StateObject var postDetailViewModel: PostDetailViewModel = PostDetailViewModel()
     
     @State private var selectedItem: PhotosPickerItem?

--- a/YeDi/YeDi/Shared/View/Chatting/ChattingListRoomView.swift
+++ b/YeDi/YeDi/Shared/View/Chatting/ChattingListRoomView.swift
@@ -29,10 +29,19 @@ struct ChattingListRoomView: View {
                             .frame(width: 0, height: 0)
                             .background()
                             
-                            DMAsyncImage(url: chattingListRoomViewModel.userProfile[chattingRoom.id]?.profileImageURLString ?? "")
-                                .aspectRatio(contentMode: .fill)
-                                .clipShape(Circle())
-                                .frame(width: 50, height: 50)
+                            if let imageURLString = chattingListRoomViewModel.userProfile[chattingRoom.id]?.profileImageURLString {
+                                DMAsyncImage(url: imageURLString)
+                                    .aspectRatio(contentMode: .fill)
+                                    .frame(width: 50, height: 50)
+                                    .clipShape(Circle())
+                            } else {
+                                Text(String(chattingListRoomViewModel.userProfile[chattingRoom.id]?.name.first ?? " ").capitalized)
+                                    .font(.title3)
+                                    .fontWeight(.bold)
+                                    .frame(width: 50, height: 50)
+                                    .background(Circle().fill(Color.quaternarySystemFill))
+                                    .foregroundColor(Color.primaryLabel)
+                            }
                                 
                             VStack(alignment: .leading, spacing: 5) {
                                 Text(chattingListRoomViewModel.userProfile[chattingRoom.id]?.name ?? "UnKown")


### PR DESCRIPTION
문제 상황
- 채팅방 내에서 바로예약 버튼 클릭 후 예약 뷰를 dismiss 하면 같은 채팅 메시지가 하나 더 생기는 이슈가 있었습니다.

해결 !
- ChatRoomView에서 채팅 버블 메시지를 ForEach 해주는 구문에서 `Set`을 사용하여 중복된 메시지를 제거하였습니다.

<img src="https://github.com/APPSCHOOL3-iOS/final-yedi/assets/68881093/0083ea1c-2055-4e38-ac9d-f8ece205a73d" width="300" />
<img src="https://github.com/APPSCHOOL3-iOS/final-yedi/assets/68881093/a0c18202-f95d-4035-9fbd-59968bd25c25" width="300" />