### PR TITLE
Fix: 배열에 set을 사용하여 채팅 메시지 순서가 꼬이는 이슈 해결

### DIFF
--- a/YeDi/YeDi/Shared/View/Chatting/ChatRoomView.swift
+++ b/YeDi/YeDi/Shared/View/Chatting/ChatRoomView.swift
@@ -85,7 +85,7 @@ struct ChatRoomView: View {
                     Text(String(userProfile.name.first ?? " ").capitalized)
                         .font(.title3)
                         .fontWeight(.bold)
-                        .frame(width: 50, height: 50)
+                        .frame(width: 30, height: 30)
                         .background(Circle().fill(Color.quaternarySystemFill))
                         .foregroundColor(Color.primaryLabel)
                         .offset(y: -5)
@@ -131,7 +131,7 @@ struct ChatRoomView: View {
                     .padding(.vertical)
                 }
                 
-                ForEach(Array(Set(chattingVM.chattings))) { chat in
+                ForEach(chattingVM.chattings) { chat in
                     var isMyBubble: Bool {
                         chat.sender == userId ? true : false
                     }

--- a/YeDi/YeDi/Shared/ViewModel/Chatting/ChattingViewModel.swift
+++ b/YeDi/YeDi/Shared/ViewModel/Chatting/ChattingViewModel.swift
@@ -53,8 +53,16 @@ class ChattingViewModel: ObservableObject {
                         let bubble = try diff.document.data(as: CommonBubble.self)
                         
                         if (diff.type == .added) {
+                            let isDuplicate = self?.chattings.contains { exist in
+                                return exist.id == bubble.id
+                            }
+                            
                             ///채팅에 새로운 버블 추가
-                            self?.chattings.append(bubble)
+                            if let isDuplicate = isDuplicate {
+                                if !isDuplicate {
+                                    self?.chattings.append(bubble)
+                                }
+                            }
                         }
                         
                         if (diff.type == .modified) {


### PR DESCRIPTION
문제 상황
- 채팅방에서 바로예약 버튼 클릭 후 되돌아오면 같은 메시지가 생기는 이슈가 있어 이를 해결하기 위해 채팅 버블 배열에 set을 사용하여 중복을 제거했었습니다.
- 하지만 set은 중복을 제거하지만 순서를 없애기 때문에 메시지를 불러오는 과정에서 순서가 뒤죽박죽이 되는 문제가 발생했습니다.

해결 !
- set을 없애고, ChattindViewModel에서 채팅 버블을 fetch하는 함수 내에서 새로운 메시지와 기존 메시지 id를 비교하여 같은 id를 가지는 버블의 중복을 피하였습니다.