### PR TITLE
Fix: 시술 내역이 여러개일 때 뷰가 깨지는 현상 수정

### DIFF
--- a/YeDi/YeDi/Client/View/CMReservation/CMReservationHistory/CMReservationHistoryDetailView.swift
+++ b/YeDi/YeDi/Client/View/CMReservation/CMReservationHistory/CMReservationHistoryDetailView.swift
@@ -42,16 +42,23 @@ struct CMReservationHistoryDetailView: View {
     
     // MARK: - Body
     var body: some View {
-        NavigationStack {
+        ScrollView {
             VStack(alignment: .leading, spacing: 30) {
                 Group {
                     // MARK: - 디자이너 정보 섹션
                     VStack(alignment: .leading, spacing: 10) {
                         Text("\(designerRank) \(designerName)")
                             .font(.title3)
-                        ForEach(styles, id: \.self) { style in
-                            Text("\(style)")
-                                .font(.title)
+                        HStack {
+                            ForEach(styles, id: \.self) { style in
+                                if styles.last == style {
+                                    Text("\(style)")
+                                        .font(.title)
+                                } else {
+                                    Text("\(style),")
+                                        .font(.title)
+                                }
+                            }
                         }
                     }
                     .fontWeight(.semibold)

--- a/YeDi/YeDi/Client/View/CMReservation/CMReservationHistory/CMReservationHistoryView.swift
+++ b/YeDi/YeDi/Client/View/CMReservation/CMReservationHistory/CMReservationHistoryView.swift
@@ -10,7 +10,8 @@ import SwiftUI
 /// 예약 내역 뷰
 struct CMReservationHistoryView: View {
     // MARK: - Properties
-    @EnvironmentObject var historyViewModel: CMHistoryViewModel
+    @EnvironmentObject var userAuth: UserAuth
+    @EnvironmentObject var cmHistoryViewModel: CMHistoryViewModel
     
     @State var selectedSegment: String = "다가오는 예약"
     


### PR DESCRIPTION
- 시술 내역 horizontal하게 표시되도록 변경
- 예약 내역 디테일 뷰 > 스크롤 뷰로 변경
<img src="https://github.com/APPSCHOOL3-iOS/final-yedi/assets/72439620/1953ee16-2d36-49fc-8fe3-abdad003c434" width=250>
<img src="https://github.com/APPSCHOOL3-iOS/final-yedi/assets/72439620/77b9d71d-3858-4ccf-9308-6c5b5a9d2f68" width=250>
