### PR TITLE
Fix/Refactor: 채팅 관련 View 코드 정리 및 채팅방 리스트 관련 이슈 해결

### DIFF
--- a/YeDi/YeDi/Shared/View/Chatting/BoardBubbleCell.swift
+++ b/YeDi/YeDi/Shared/View/Chatting/BoardBubbleCell.swift
@@ -8,8 +8,8 @@
 import SwiftUI
 
 struct BoardBubbleCell: View {
-    var boardBubble: CommonBubble
-    var isMyBubble: Bool
+    let boardBubble: CommonBubble
+    let isMyBubble: Bool
     
     var body: some View {
         VStack(alignment: .leading) {

--- a/YeDi/YeDi/Shared/View/Chatting/BubbleCell.swift
+++ b/YeDi/YeDi/Shared/View/Chatting/BubbleCell.swift
@@ -8,8 +8,8 @@
 import SwiftUI
 
 struct BubbleCell: View {
-    var chat: CommonBubble
-    var isMyBubble: Bool
+    let chat: CommonBubble
+    let isMyBubble: Bool
     
     private var chatTime: String {
         let instance = FirebaseDateFomatManager.sharedDateFommatter
@@ -61,7 +61,7 @@ struct BubbleCell: View {
     }
     
     private var chatDateMark: some View {
-        Text("\(chatTime)")
+        Text(changetoDateFormat(chat.date))
             .font(.caption2)
             .foregroundStyle(.gray)
     }
@@ -70,5 +70,32 @@ struct BubbleCell: View {
         Circle()
             .frame(width: 8, height: 8)
             .foregroundStyle(Color.subColor)
+    }
+    
+    /// 채팅방  최근 메세지 날짜 표출형식 커스텀 메소드
+    private func changetoDateFormat(_ messageDate: String) -> String {
+        let dateFomatter = FirebaseDateFomatManager.sharedDateFommatter.firebaseDateFormat()
+        let date = dateFomatter.date(from: messageDate) ?? Date()
+        let calendar = Calendar.current
+        
+        if calendar.isDateInToday(date) {
+            dateFomatter.dateFormat = "HH:mm"
+            return dateFomatter.string(from: date)
+        } else if calendar.isDateInYesterday(date) {
+            return "어제"
+        } else {
+            let currentYear = calendar.component(.year, from: Date())
+            let messageYear = calendar.component(.year, from: date)
+            // 올해 년도의 메세지인 경우 월/일 반환
+            if currentYear == messageYear {
+                dateFomatter.dateFormat = "MM/dd HH:mm"
+                return dateFomatter.string(from: date)
+            } else {
+                // 그 외 올해가 아닌 데이터 날짜는 년.월, 일 형식의 String을 반환
+                let formatter = DateFormatter()
+                formatter.dateFormat = "yyyy.MM.dd HH:mm"
+                return formatter.string(from: date)
+            }
+        }
     }
 }

--- a/YeDi/YeDi/Shared/View/Chatting/ChatRoomSheetView.swift
+++ b/YeDi/YeDi/Shared/View/Chatting/ChatRoomSheetView.swift
@@ -8,9 +8,10 @@
 import SwiftUI
 
 struct ChatRoomSheetView: View {
-    @State var chatRoomId: String
     @EnvironmentObject var consultationViewModel: ConsultationViewModel
     @Environment(\.colorScheme) var colorScheme
+    
+    @State var chatRoomId: String
     
     var body: some View {
         NavigationStack {

--- a/YeDi/YeDi/Shared/View/Chatting/ChatRoomView.swift
+++ b/YeDi/YeDi/Shared/View/Chatting/ChatRoomView.swift
@@ -8,10 +8,10 @@
 import SwiftUI
 
 struct ChatRoomView: View {
-    var chatRoomId: String
+    let chatRoomId: String
     
     @StateObject var chattingVM = ChattingViewModel()
-    @ObservedObject var chattingListRoomViewModel = ChattingListRoomViewModel()
+    @StateObject var chattingListRoomViewModel = ChattingListRoomViewModel()
     @EnvironmentObject var userAuth: UserAuth
     
     @State private var inputText: String = ""
@@ -43,7 +43,6 @@ struct ChatRoomView: View {
     }
     
     var body: some View {
-        let _ = print("============= chat room : \(chatRoomId)")
         VStack(spacing: 0) {
             chatScroll
             inputchatTextField
@@ -104,7 +103,7 @@ struct ChatRoomView: View {
     
     private var chatScroll: some View {
         ScrollView {
-            VStack{
+            VStack {
                 if chattingVM.anyMoreChats {
                     ZStack {
                         Divider()

--- a/YeDi/YeDi/Shared/View/Chatting/ChatUtilityMenuView.swift
+++ b/YeDi/YeDi/Shared/View/Chatting/ChatUtilityMenuView.swift
@@ -9,9 +9,9 @@ import SwiftUI
 import PhotosUI
 
 struct ChatUtilityMenuView: View {
-    var userID: String
-    var designerID: String
-    var chatRoomId: String
+    let userID: String
+    let designerID: String
+    let chatRoomId: String
     
     @EnvironmentObject var userAuth: UserAuth
     @StateObject var chattingVM = ChattingViewModel()
@@ -22,14 +22,12 @@ struct ChatUtilityMenuView: View {
     @State private var isPresentedNavigation: Bool = false
     
     var body: some View {
-        
-        let _ = print("======================== menu : \(chatRoomId)")
         HStack {
             Spacer()
             
             PhotosPicker(selection: $selectedItem, matching: .images) {
                 VStack {
-                    VStack{
+                    VStack {
                         Image(systemName: "photo.circle.fill")
                             .resizable()
                             .scaledToFit()
@@ -62,7 +60,7 @@ struct ChatUtilityMenuView: View {
                     isPresentedAlert.toggle()
                 }, label: {
                     VStack {
-                        VStack{
+                        VStack {
                             Image(systemName: "clock.fill")
                                 .resizable()
                                 .scaledToFit()

--- a/YeDi/YeDi/Shared/View/Chatting/ChattingListRoomView.swift
+++ b/YeDi/YeDi/Shared/View/Chatting/ChattingListRoomView.swift
@@ -90,6 +90,9 @@ struct ChattingListRoomView: View {
         .onAppear {
             chattingListRoomViewModel.fetchChattingList(login: userAuth.userType)
         }
+        .onDisappear {
+            chattingListRoomViewModel.removeListener()
+        }
     }
     
     /// 채팅방 리스트 최근 메세지 날짜 표출형식 커스텀 메소드

--- a/YeDi/YeDi/Shared/View/Chatting/DateDeviderCell.swift
+++ b/YeDi/YeDi/Shared/View/Chatting/DateDeviderCell.swift
@@ -8,9 +8,9 @@
 import SwiftUI
 
 struct DateDeviderCell: View {
+    let chat: CommonBubble
+    let chattingVM: ChattingViewModel
     
-    var chat: CommonBubble
-    var chattingVM: ChattingViewModel
     @Binding var devideDate: String
     
     private var chatDate: String {
@@ -20,18 +20,17 @@ struct DateDeviderCell: View {
     }
     
     var body: some View {
-        VStack{
+        VStack {
             if chatDate == devideDate { //다른 경우
                 Text("\(chatDate)")
             } else {
                 if !chattingVM.anyMoreChats && chatDate != devideDate {
                     Text("\(chatDate)")
-                        .onAppear{
-                        devideDate = chatDate
-                    }
+                        .onAppear {
+                            devideDate = chatDate
+                        }
                 }
             }
         }
     }
 }
-

--- a/YeDi/YeDi/Shared/View/Chatting/ImageBubbleCell.swift
+++ b/YeDi/YeDi/Shared/View/Chatting/ImageBubbleCell.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct ImageBubbleCell: View {
-    var imagePath: String
+    let imagePath: String
     
     var body: some View {
         AsnycCacheImage(url: imagePath)

--- a/YeDi/YeDi/Shared/ViewModel/Chatting/ChattingListRoomViewModel.swift
+++ b/YeDi/YeDi/Shared/ViewModel/Chatting/ChattingListRoomViewModel.swift
@@ -18,6 +18,7 @@ final class ChattingListRoomViewModel: ObservableObject {
     @Published var isEmptyChattingList: Bool = true
     
     let storeService = Firestore.firestore()
+    var sotreListener: ListenerRegistration?
     
     var getUnReadTotalCount: Int {
         var totalCount = 0
@@ -50,6 +51,10 @@ final class ChattingListRoomViewModel: ObservableObject {
         return  Auth.auth().currentUser?.uid
     }
     
+    final func removeListener() {
+        sotreListener?.remove()
+    }
+    
     /// 전달된 user UUID 값으로 채팅방 UUID리스트를 추출
     /// - 유저 Document의 이벤트 리스너가 채팅방 리스트가 추가 될 때마다 채팅방 정보를 갱신
     private final func fetchChattingRoomIdList(user uid: String, loginType: UserType) {
@@ -61,7 +66,7 @@ final class ChattingListRoomViewModel: ObservableObject {
             docRef = storeService.collection("designers").document(uid)
         }
         
-        docRef.addSnapshotListener {[weak self] (snapshot, error) in
+        docRef.addSnapshotListener { [weak self] (snapshot, error) in
             if let error = error {
                 debugPrint("Error getting cahtRooms: \(error)")
             } else if let document = snapshot, document.exists {
@@ -88,6 +93,8 @@ final class ChattingListRoomViewModel: ObservableObject {
     /// 채팅방의 메세지 내역을 가지고오는 메소드
     /// - 채팅방에서 가장 최근 메세지 한 개만 조회
     private final func fetchChattingBubble(chatRoom id: String) {
+        chattingRooms.removeAll()
+        
         let bubblePath = "chatRooms/\(id)/bubbles"
         let ref = storeService.collection(bubblePath).order(by: "date", descending: true).limit(to: 1)
         


### PR DESCRIPTION
- 채팅 관련 View 코드 정리
- 채팅방 내 날짜, 시간 포맷 함수 생성
- 같은 기기에서 다른 계정 로그인 시 나타나는 채팅방 리스트 관련 이슈 해결
    - 채팅방 리스트에 이전 로그인 계정의 리스트까지 보이는 이슈 해결
        - ChattingListRoomViewModel의 `fetchChattingBubble()`함수 초기에 `chattingRooms.removeAll()` 코드 삽입
    - 채팅 탭바 notification에도 이전 로그인 계정의 데이터가 나타나는 이슈 해결
        - ChattingListRoomViewModel에 리스너를 제거하는 함수를 만들어 `ChattingListRoomView`가 onDisappear될 때 해당 함수를 호출하도록 함
<img src="https://github.com/APP-iOS2/final-yedi/assets/68881093/171ef74b-ceeb-4a62-a419-5bc6bfafb028" width="300" />
<img src="https://github.com/APP-iOS2/final-yedi/assets/68881093/2367653b-9b5a-433b-b60a-5f85493b04e8" width="300" />

